### PR TITLE
Run apt-get update before installing packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,11 @@
 FROM quay.io/democracyworks/clojure-api-supervisor:latest
 MAINTAINER Democracy Works, Inc. <dev@democracy.works>
 
-# install MongoDB
-RUN apt-get install -y mongodb
-RUN mkdir -p /data/db
+# install some dependent packages
+RUN apt-get update && apt-get install -y mongodb git build-essential libfreetype6 libfontconfig
 
-# install git (bower dependency)
-RUN apt-get install -y git
+# create MongoDB data dir
+RUN mkdir -p /data/db
 
 # install Node
 RUN add-apt-repository -y ppa:chris-lea/node.js
@@ -21,9 +20,6 @@ RUN apt-get install -y nodejs
 # install Grunt
 RUN npm install -g grunt-cli
 RUN npm install -g bower
-
-# install build-essential for dependencies that need that stuff
-RUN apt-get install -y build-essential
 
 # install app dependencies
 RUN mkdir /metis
@@ -44,7 +40,6 @@ RUN ln -s /metis/docker/supervisord-metis.conf /etc/supervisor/conf.d/
 RUN cd /metis && bower --allow-root install
 
 # setup test environment
-RUN apt-get install -y libfreetype6 libfontconfig # needed by phantomjs
 RUN ln -s /metis/docker/run-tests.sh /run-tests.sh
 
 # run the app


### PR DESCRIPTION
This helps prevent the missing packages problem. Still not a perfect
solution, of course, but hey, it builds now.