### PR TITLE
[CS] Fix running Metis inside docker.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,4 +49,3 @@ RUN ln -s /metis/docker/run-tests.sh /run-tests.sh
 
 # run the app
 EXPOSE 4000 27017 28017
-CMD ["/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,11 @@ FROM quay.io/democracyworks/clojure-api-supervisor:latest
 MAINTAINER Democracy Works, Inc. <dev@democracy.works>
 
 # install MongoDB
-RUN apt-get install -y mongodb
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 7F0CEB10
+RUN echo 'deb http://downloads-distro.mongodb.org/repo/debian-sysvinit dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list
+RUN apt-get update
+
+RUN apt-get install -y mongodb-org
 RUN mkdir -p /data/db
 
 # install git (bower dependency)


### PR DESCRIPTION
There is no "/run.sh". There is no CMD. Supervisor takes care of everything.