### PR TITLE
Front end updates 2

### DIFF
--- a/public/app/partials/feed-overview.html
+++ b/public/app/partials/feed-overview.html
@@ -36,16 +36,46 @@
 
 <section class="data-group data-module started">
   <header class="data-group-header">
-    <h2>{{feedLocalities.length}} Localities
-    <small>({{feedCounties.features.length}} Counties)</small></h2>
-    <span ng-if="!feedCounties" class="more-detail is-loading"></span>
-    <a class="more-detail" ng-if="feedCounties" href="{{$location.absUrl()}}/election/state/localities/">More Detail</a>
+    <h2>{{feedLocalities.length}} Localities</h2>
+
+    <span ng-if="!feedLocalities" class="more-detail is-loading"></span>
+    <a class="more-detail" ng-if="feedLocalities" href="{{$location.absUrl()}}/election/state/localities/">More Detail</a>
   </header>
 
   <!-- element table directive -->
-  <span ng-if="!feedCounties" class="is-loading"></span>
-  <div id="map" class="map" hidden></div>
+  <section class="data-group data-module">
+    <div ng-if="!feedLocalities"></br><span class="is-loading"></span></div>
+    
+    <table ng-show="feedLocalities.length" id="LocalTable" ng-table="localTableParams" template-pagination="localPagination" class="associations">
+      <tr id="locality{{$index}}" ng-repeat="locality in $data">
+        <td id="locality-id{{$index}}" class="id" data-title="'ID'" sortable="'id'">
+          <a href="{{locality.self}}" data-title-text="ID">
+            <span class="td-text">{{locality.id}}</span>
+          </a>
+        </td>
+        <td id="locality-name{{$index}}" class="name" data-title="'Name'" sortable="'name'">
+          <a href="{{locality.self}}" data-title-text="Name">
+            <span class="td-text">{{locality.name}}</span>
+          </a>
+        </td>
+        <td id="locality-precincts{{$index}}" class="precincts" data-title="'Precincts'" sortable="'precints'">
+          <a href="{{locality.self}}" data-title-text="Precincts">
+            <span class="td-text">{{locality.precincts}}</span>
+          </a>
+        </td>
+      </tr>
+    </table>
 
+    <script type="text/ng-template" id="localPagination">
+      <ul class="pagination ng-cloak">
+        <li ng-repeat="page in pages"
+            ng-class="{'ng-hide': page.type == 'prev' || page.type == 'next'}">
+          <a id="feedsPage{{$index}}" ng-class="{'is-active': page.number == localTableParams.page()}"
+             ng-click="localTableParams.page(page.number)" href="">{{page.number}}</a>
+        </li>
+      </ul>
+    </script>
+  </section>
 </section>
 <!-- /.data-group -->
 

--- a/public/app/partials/feed-overview.html
+++ b/public/app/partials/feed-overview.html
@@ -28,9 +28,39 @@
   </header>
 
   <!-- element table directive -->
-  <span ng-if="!feedPollingLocations" class="is-loading"></span>
-  <div ng-show="feedPollingLocations.length" ng-overviewtable ng-model="feedPollingLocations" loading="feedPollingLocations" label="pollingLocation"></div>
+  <section class="data-group data-module">
+    <div ng-if="!feedPollingLocations"></br><span class="is-loading"></span></div>
+    
+    <table class="overview" ng-show="feedPollingLocations.length" id="pollingTable" template-pagination="pollingPagination" ng-table="pollingTableParams" class="associations">
+      <tr id="pollingLocation{{$index}}" ng-repeat="pollingLocation in $data">
+        <td data-title="'Element Type'" sortable="'element_type'" id="pollingLocation-element-type{{$index}}" class="element-type"><span data-title-text="Element Type">{{pollingLocation.element_type}}</span></td>
+        <td data-title="'Amount'" sortable="'amount'" id="pollingLocation-amount{{$index}}" class="numeric amount"><span data-title-text="Amount">{{pollingLocation.amount | number}}</span></td>
+        <td data-title="'Completion'" sortable="'complete_pct'" id="pollingLocation-complete{{$index}}" class="completion">
+          <div data-title-text="Completion" class="completeness">
+            <span class="complete-{{pollingLocation.complete_pct}}"></span>
+            <div class="counter">{{pollingLocation.complete_pct | number}}% <span class="counter-text">complete</span></div>
+          </div>
+        </td>
+        <td data-title="'Errors'" sortable="'error_count'" id="pollingLocation-errors{{$index}}" class="numeric element-errors">
+          <a data-title-text="Errors" title="View the Errors" ng-class="{default_pointer: pollingLocation.error_count===0}" href="{{pollingLocation.error_count===0 ? 'javascript: void(0);' : pollingLocation.self}}">
+            <div errorvalue="{{pollingLocation.error_count}}" ng-class="{none: pollingLocation.error_count===0}"
+                  class="errors">{{pollingLocation.error_count | number}} <span class="error-text" ng-if="pollingLocation.error_count===1">error</span><span class="error-text" ng-if="pollingLocation.error_count!=1">errors</span> <span ng-if="pollingLocation.error_count===0"><i class="fi-check"></i></span><span ng-if="pollingLocation.error_count!=0"><i class="fi-alert"></i></span>
+            </div>
+          </a>
+        </td>
+      </tr>
+    </table>
 
+    <script type="text/ng-template" id="pollingPagination">
+      <ul class="pagination ng-cloak">
+        <li ng-repeat="page in pages"
+            ng-class="{'ng-hide': page.type == 'prev' || page.type == 'next'}">
+          <a id="feedsPage{{$index}}" ng-class="{'is-active': page.number == pollingTableParams.page()}"
+             ng-click="pollingTableParams.page(page.number)" href="">{{page.number}}</a>
+        </li>
+      </ul>
+    </script>
+  </section>
 </section>
 <!-- /.data-group -->
 
@@ -45,8 +75,8 @@
   <!-- element table directive -->
   <section class="data-group data-module">
     <div ng-if="!feedLocalities"></br><span class="is-loading"></span></div>
-    
-    <table ng-show="feedLocalities.length" id="LocalTable" ng-table="localTableParams" template-pagination="localPagination" class="associations">
+    {{localTableParams}}
+    <table ng-show="feedLocalities.length" id="localTable" ng-table="localTableParams" template-pagination="localPagination" class="associations">
       <tr id="locality{{$index}}" ng-repeat="locality in $data">
         <td id="locality-id{{$index}}" class="id" data-title="'ID'" sortable="'id'">
           <a href="{{locality.self}}" data-title-text="ID">
@@ -88,7 +118,39 @@
 
   <!-- element table directive -->
   <span ng-if="!feedContests" class="is-loading"></span>
-  <div ng-show="feedContests.length" ng-overviewtable ng-model="feedContests" loading="feedContests" label="feedContests"></div>
+  <section class="data-group data-module">
+    <div ng-if="!feedContests"></br><span class="is-loading"></span></div>
+    
+    <table class="overview" ng-show="feedContests.length" id="contestTable" template-pagination="pollingPagination" ng-table="contestTableParams" class="associations">
+      <tr id="feedContests{{$index}}" ng-repeat="contest in $data">
+        <td data-title="'Element Type'" sortable="'element_type'" id="feedContests-element-type{{$index}}" class="element-type"><span data-title-text="Element Type">{{contest.element_type}}</span></td>
+        <td data-title="'Amount'" sortable="'amount'" id="feedContests-amount{{$index}}" class="numeric amount"><span data-title-text="Amount">{{contest.amount | number}}</span></td>
+        <td data-title="'Completion'" sortable="'complete_pct'" id="feedContests-complete{{$index}}" class="completion">
+          <div data-title-text="Completion" class="completeness">
+            <span class="complete-{{contest.complete_pct}}"></span>
+            <div class="counter">{{contest.complete_pct | number}}% <span class="counter-text">complete</span></div>
+          </div>
+        </td>
+        <td data-title="'Errors'" sortable="'error_count'" id="feedContests-errors{{$index}}" class="numeric element-errors">
+          <a data-title-text="Errors" title="View the Errors" ng-class="{default_pointer: contest.error_count===0}" href="{{contest.error_count===0 ? 'javascript: void(0);' : contest.self}}">
+            <div errorvalue="{{contest.error_count}}" ng-class="{none: contest.error_count===0}"
+                  class="errors">{{contest.error_count | number}} <span class="error-text" ng-if="contest.error_count===1">error</span><span class="error-text" ng-if="contest.error_count!=1">errors</span> <span ng-if="contest.error_count===0"><i class="fi-check"></i></span><span ng-if="contest.error_count!=0"><i class="fi-alert"></i></span>
+            </div>
+          </a>
+        </td>
+      </tr>
+    </table>
+
+    <script type="text/ng-template" id="pollingPagination">
+      <ul class="pagination ng-cloak">
+        <li ng-repeat="page in pages"
+            ng-class="{'ng-hide': page.type == 'prev' || page.type == 'next'}">
+          <a id="feedsPage{{$index}}" ng-class="{'is-active': page.number == contestTableParams.page()}"
+             ng-click="contestTableParams.page(page.number)" href="">{{page.number}}</a>
+        </li>
+      </ul>
+    </script>
+  </section>
 
 </section>
 <!-- /.data-group -->

--- a/public/app/partials/feed-overview.html
+++ b/public/app/partials/feed-overview.html
@@ -155,4 +155,60 @@
 </section>
 <!-- /.data-group -->
 
+<section class="data-group data-module started">
+  <header class="data-group-header">
+    <h2>Source &amp; Election</h2>
+    <span ng-if="!feedSource" class="more-detail is-loading"></span>
+    <a id="state-link" ng-if="feedSource" class="more-detail" href="{{$location.absUrl()}}/source">More Detail</a>
+  </header>
+
+  <!-- element table directive -->
+  <table class="overview">
+    <thead>
+      <tr>
+        <th>Element Type</th>
+        <th class="numeric">Amount</th>
+        <th>Completion</th>
+        <th class="numeric">Errors</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr id="feedSource">
+        <td id="feedSource-element-type" class="element-type">Source</td>
+        <td id="feedSource-amount" class="numeric amount">{{feedSource ? 1 : 0}}</td>
+        <td id="feedSource-complete" class="completion">
+          <div class="completeness">
+            <span class="complete-{{feedSource.complete_pct}}"></span>
+            <div class="counter">{{feedSource.complete_pct | number}}% <span class="counter-text">complete</span></div>
+          </div>
+        </td>
+        <td id="feedSource-errors" class="numeric element-errors">
+          <a title="View the Errors" ng-class="{default_pointer: feedSource.error_count===0}" href="{{feedSource.error_count===0 ? 'javascript: void(0);' : feedSource.self}}">
+            <div errorvalue="{{feedSource.error_count}}" ng-class="{none: feedSource.error_count===0}"
+                  class="errors">{{feedSource.error_count | number}} <span class="error-text" ng-if="feedSource.error_count===1">error</span><span class="error-text" ng-if="feedSource.error_count!=1">errors</span> <span ng-if="feedSource.error_count===0"><i class="fi-check"></i></span><span ng-if="feedSource.error_count!=0"><i class="fi-alert"></i></span>
+            </div>
+          </a>
+        </td>
+      </tr>
+      <tr id="feedElection">
+        <td id="feedElection-element-type" class="element-type">Election</td>
+        <td id="feedElection-amount" class="numeric amount">{{feedElection ? 1 : 0}}</td>
+        <td id="feedElection-complete" class="completion">
+          <div class="completeness">
+            <span class="complete-{{feedElection.complete_pct}}"></span>
+            <div class="counter">{{feedElection.complete_pct | number}}% <span class="counter-text">complete</span></div>
+          </div>
+        </td>
+        <td id="feedElection-errors" class="numeric element-errors">
+          <a title="View the Errors" ng-class="{default_pointer: feedElection.error_count===0}" href="{{feedElection.error_count===0 ? 'javascript: void(0);' : feedElection.self}}">
+            <div errorvalue="{{feedElection.error_count}}" ng-class="{none: feedElection.error_count===0}"
+                  class="errors">{{feedElection.error_count | number}} <span class="error-text" ng-if="feedElection.error_count===1">error</span><span class="error-text" ng-if="feedElection.error_count!=1">errors</span> <span ng-if="feedElection.error_count===0"><i class="fi-check"></i></span><span ng-if="feedElection.error_count!=0"><i class="fi-alert"></i></span>
+            </div>
+          </a>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
 </div>

--- a/public/app/partials/feed-state.html
+++ b/public/app/partials/feed-state.html
@@ -2,42 +2,40 @@
 
 <p ng-if="feedState.error_count !== undefined"><a id="state-errors" class="error-count error-count-{{feedState.error_count}}" href="{{$location.absUrl()}}/errors">{{feedState.error_count}} Errors in State ID: {{feedState.id}}</a></p>
 
-<div class="data-module-full">
-  <dl class="attributes">
-    <dt class="key">Name:</dt>
-    <dd class="value">{{feedState.name}}</dd>
-    <dt class="key">Abbreviation:</dt>
-    <dd class="value">{{feedState.abbreviation}}</dd>
-    <dt class="key">Region:</dt>
-    <dd class="value">{{feedState.region}}</dd>
-  </dl>
-</div>
-
 <section class="data-group data-module">
-  <h2>{{feedEarlyVoteSites.length}} Early Vote Sites</h2>
+  <h2>State</h2>
 
-  <span ng-if="!feedEarlyVoteSites" class="is-loading"></span>
-  <table ng-show="feedEarlyVoteSites.length" id="earlyVoteTable" ng-table="earlyVoteTableParams"
-         template-pagination="earlyVotePagination" class="associations">
-    <tr id="earlyVoteSite{{$index}}" ng-repeat="earlyVoteSite in $data">
-      <td id="earlyVoteSite-id{{$index}}" data-title="'ID'" sortable="'id'"><a href="{{earlyVoteSite.self}}" data-title-text="ID"><span class="td-text">{{earlyVoteSite.id}}</span></a>
-      </td>
-      <td id="earlyVoteSite-name{{$index}}" data-title="'Name'" sortable="'name'"><a href="{{earlyVoteSite.self}}" data-title-text="Name"><span class="td-text">{{earlyVoteSite.name}}</span></a>
-      </td>
-      <td id="earlyVoteSite-address{{$index}}" data-title="'Address'" sortable="'address'"><a href="{{earlyVoteSite.self}}" data-title-text="Address"><span class="td-text">{{earlyVoteSite.address}}</span></a>
+  <span ng-if="!feedElection" class="is-loading"></span>
+  <table ng-if="feedElection.state" class="associations">
+    <thead>
+    <tr>
+      <th>ID</th>
+      <th>Name</th>
+      <th>Localities</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td id="state-id" class="id"><a href="{{$location.absUrl()}}" data-title-text="ID"><span class="td-text">{{feedElection.state.id}}</span></a></td>
+      <td id="state-name" class="name"><a href="{{$location.absUrl()}}" data-title-text="Name"><span class="td-text">{{feedElection.state.name}}</span></a></td>
+      <td id="state-localities" class="localities"><a href="{{$location.absUrl()}}" data-title-text="Localities"><span class="td-text">{{feedElection.state.locality_count}}</span></a>
       </td>
     </tr>
+    </tbody>
   </table>
 
-  <script type="text/ng-template" id="earlyVotePagination">
-    <ul class="pagination ng-cloak">
-      <li ng-repeat="page in pages"
-          ng-class="{'ng-hide': page.type == 'prev' || page.type == 'next'}">
-        <a id="feedsPage{{$index}}" ng-class="{'is-active': page.number == earlyVoteTableParams.page()}"
-           ng-click="earlyVoteTableParams.page(page.number)" href="">{{page.number}}</a>
-      </li>
-    </ul>
-  </script>
+</section>
+
+<section class="data-group data-module started">
+  <header class="data-group-header">
+    <h2>Polling Locations</h2>
+    <span ng-if="!feedPollingLocations" class="more-detail is-loading"></span>
+    <a id="state-link" ng-if="feedPollingLocations" class="more-detail" href="{{$location.absUrl()}}/election/state">More Detail</a>
+  </header>
+
+  <!-- element table directive -->
+  <span ng-if="!feedPollingLocations" class="is-loading"></span>
+  <div ng-show="feedPollingLocations.length" ng-overviewtable ng-model="feedPollingLocations" loading="feedPollingLocations" label="pollingLocation"></div>
 
 </section>
 
@@ -66,14 +64,8 @@
 </section><!-- /.data-group -->
 
 <section class="data-group data-module">
-  <h2>{{feedLocalities.length}} Localities
-    <small>({{feedCounties.features.length}} Counties)</small>
-  </h2>
-  <span ng-if="!feedCounties" class="is-loading"></span>
-  <div id="map" class="map" hidden></div>
-</section>
+  <h2>{{feedLocalities.length}} Localities</h2>
 
-<section class="data-group data-module">
   <div ng-if="!feedLocalities"></br><span class="is-loading"></span></div>
   <table ng-show="feedLocalities.length" id="LocalTable" ng-table="localTableParams" template-pagination="localPagination"
          class="associations">

--- a/public/assets/js/app/app.js
+++ b/public/assets/js/app/app.js
@@ -493,6 +493,7 @@ vipApp.run(function ($rootScope, $appService, $location, $httpBackend, $appPrope
    */
   $rootScope.createTableParams = function(ngTableParams, $filter, data, count, sorting) {
     // sets the defaults for the table sorting parameters
+
     return new ngTableParams({
       page: 1,
       count: count,
@@ -501,6 +502,12 @@ vipApp.run(function ($rootScope, $appService, $location, $httpBackend, $appPrope
       total: data.length,
       // sets the type of sorting for the table
       getData: function ($defer, params) {
+        // change any IDs to integers for smarter sorting
+        $.map(data, function(row) {
+          if (row['id']) row['id'] = parseInt(row['id']);
+          return row;
+        });
+
         var orderedData = params.sorting() ? $filter('orderBy')(data, params.orderBy()) : data;
         $defer.resolve(orderedData.slice((params.page() - 1) * params.count(), params.page() * params.count()));
       }

--- a/public/assets/js/app/controllers/feedOverviewController.js
+++ b/public/assets/js/app/controllers/feedOverviewController.js
@@ -3,7 +3,7 @@
  * Feeds Overview Controller
  *
  */
-function FeedOverviewCtrl($scope, $rootScope, $feedsService, $routeParams, $location) {
+function FeedOverviewCtrl($scope, $rootScope, $feedsService, $routeParams, $location, $appProperties, $filter, ngTableParams) {
 
   // get the vipfeed param from the route
   var feedid = $routeParams.vipfeed;
@@ -26,8 +26,7 @@ function FeedOverviewCtrl($scope, $rootScope, $feedsService, $routeParams, $loca
       // now call the other services to get the rest of the data
       FeedOverviewCtrl_getFeedPollingLocations($scope, $rootScope, $feedsService, data.polling_locations);
       FeedOverviewCtrl_getFeedContests($scope, $rootScope, $feedsService, data.contests);
-      FeedOverviewCtrl_getFeedLocalities($scope, $rootScope, $feedsService, data.localities);
-      FeedOverviewCtrl_getFeedCounties($scope, $rootScope, $feedsService, data.county_map);
+      FeedOverviewCtrl_getFeedLocalities($scope, $rootScope, $feedsService, data.localities, $appProperties, $filter, ngTableParams);
 
     }).error(function (data, $http) {
 
@@ -98,14 +97,19 @@ function FeedOverviewCtrl_getFeedContests($scope, $rootScope, $feedsService, ser
  * Get the Feed Localities for the Feed Overview page
  *
  */
-function FeedOverviewCtrl_getFeedLocalities($scope, $rootScope, $feedsService, servicePath){
+function FeedOverviewCtrl_getFeedLocalities($scope, $rootScope, $feedsService, servicePath, $appProperties, $filter, ngTableParams){
 
   // get Results
   $feedsService.getFeedLocalities(servicePath)
     .success(function (data) {
 
+      // use the self property to use as the linked URL for each item
+      $rootScope.changeSelfToAngularPath(data);
+
       // set the feeds data into the Angular model
       $scope.feedLocalities = data;
+
+      $scope.localTableParams = $rootScope.createTableParams(ngTableParams, $filter, data, $appProperties.lowPagination, { id: 'asc' });
 
     }).error(function (data) {
 
@@ -113,30 +117,5 @@ function FeedOverviewCtrl_getFeedLocalities($scope, $rootScope, $feedsService, s
 
       // so the loading spinner goes away and we are left with an empty table
       $scope.feedLocalities = {};
-    });
-}
-
-/*
- * Get the Feed Counties (Map) for the Feed Overview page
- *
- */
-function FeedOverviewCtrl_getFeedCounties($scope, $rootScope, $feedsService, servicePath){
-
-  // get Results
-  $feedsService.getFeedCounties(servicePath)
-    .success(function (data) {
-
-      // set the feeds data into the Angular model
-      $scope.feedCounties = data;
-
-      // generate the map
-      vipApp_ns.generateMap(data, $rootScope.$appProperties);
-
-    }).error(function (data) {
-
-      $rootScope.pageHeader.error += "Could not retrieve Feed Counties. ";
-
-      // so the loading spinner goes away and we are left with an empty table
-      $scope.feedCounties = {};
     });
 }

--- a/public/assets/js/app/controllers/feedOverviewController.js
+++ b/public/assets/js/app/controllers/feedOverviewController.js
@@ -24,8 +24,8 @@ function FeedOverviewCtrl($scope, $rootScope, $feedsService, $routeParams, $loca
       $rootScope.pageHeader.title = data.title;
 
       // now call the other services to get the rest of the data
-      FeedOverviewCtrl_getFeedPollingLocations($scope, $rootScope, $feedsService, data.polling_locations);
-      FeedOverviewCtrl_getFeedContests($scope, $rootScope, $feedsService, data.contests);
+      FeedOverviewCtrl_getFeedPollingLocations($scope, $rootScope, $feedsService, data.polling_locations, $appProperties, $filter, ngTableParams);
+      FeedOverviewCtrl_getFeedContests($scope, $rootScope, $feedsService, data.contests, $appProperties, $filter, ngTableParams);
       FeedOverviewCtrl_getFeedLocalities($scope, $rootScope, $feedsService, data.localities, $appProperties, $filter, ngTableParams);
 
     }).error(function (data, $http) {
@@ -53,7 +53,7 @@ function FeedOverviewCtrl($scope, $rootScope, $feedsService, $routeParams, $loca
  * Get the Feed Polling Locations for the Feed Overview page
  *
  */
-function FeedOverviewCtrl_getFeedPollingLocations($scope, $rootScope, $feedsService, servicePath){
+function FeedOverviewCtrl_getFeedPollingLocations($scope, $rootScope, $feedsService, servicePath, $appProperties, $filter, ngTableParams){
 
   // get Polling Locations
   $feedsService.getFeedPollingLocations(servicePath)
@@ -61,6 +61,8 @@ function FeedOverviewCtrl_getFeedPollingLocations($scope, $rootScope, $feedsServ
 
       // set the feeds data into the Angular model
       $scope.feedPollingLocations = data;
+
+      $scope.pollingTableParams = $rootScope.createTableParams(ngTableParams, $filter, data, $appProperties.lowPagination, { element_type: 'asc' });
 
     }).error(function (data) {
 
@@ -75,7 +77,7 @@ function FeedOverviewCtrl_getFeedPollingLocations($scope, $rootScope, $feedsServ
  * Get the Feed Contests for the Feed Overview page
  *
  */
-function FeedOverviewCtrl_getFeedContests($scope, $rootScope, $feedsService, servicePath){
+function FeedOverviewCtrl_getFeedContests($scope, $rootScope, $feedsService, servicePath, $appProperties, $filter, ngTableParams){
 
   // get Contests
   $feedsService.getFeedContests(servicePath)
@@ -83,6 +85,7 @@ function FeedOverviewCtrl_getFeedContests($scope, $rootScope, $feedsService, ser
 
       // set the feeds data into the Angular model
       $scope.feedContests = data;
+      $scope.contestTableParams = $rootScope.createTableParams(ngTableParams, $filter, data, $appProperties.lowPagination, { element_type: 'asc' });
 
     }).error(function (data) {
 
@@ -108,7 +111,6 @@ function FeedOverviewCtrl_getFeedLocalities($scope, $rootScope, $feedsService, s
 
       // set the feeds data into the Angular model
       $scope.feedLocalities = data;
-
       $scope.localTableParams = $rootScope.createTableParams(ngTableParams, $filter, data, $appProperties.lowPagination, { id: 'asc' });
 
     }).error(function (data) {

--- a/public/assets/js/app/controllers/feedOverviewController.js
+++ b/public/assets/js/app/controllers/feedOverviewController.js
@@ -137,6 +137,7 @@ function FeedOverviewCtrl_getFeedSource($scope, $rootScope, $feedsService, servi
     .success(function (data) {
 
       // temporarily sets the percentages for just the overview page
+      // '5.0' is the number of fields we're expecting from the data
       data['complete_pct'] = Math.round(Object.keys(data['source_info']).length / 5.0 * 100);
 
       // set the feeds data into the Angular model
@@ -162,6 +163,7 @@ function FeedOverviewCtrl_getFeedElection($scope, $rootScope, $feedsService, ser
     .success(function (data) {
 
       // temporarily sets the percentages for just the overview page
+      // '17.0' is the number of fields we're expecting from the data
       data['complete_pct'] = Math.round(Object.keys(data).length / 17.0 * 100);
       data['complete_pct'] = data['complete_pct'] > 100 ? 100 : data['complete_pct']
       

--- a/public/assets/js/app/controllers/feedOverviewController.js
+++ b/public/assets/js/app/controllers/feedOverviewController.js
@@ -27,6 +27,8 @@ function FeedOverviewCtrl($scope, $rootScope, $feedsService, $routeParams, $loca
       FeedOverviewCtrl_getFeedPollingLocations($scope, $rootScope, $feedsService, data.polling_locations, $appProperties, $filter, ngTableParams);
       FeedOverviewCtrl_getFeedContests($scope, $rootScope, $feedsService, data.contests, $appProperties, $filter, ngTableParams);
       FeedOverviewCtrl_getFeedLocalities($scope, $rootScope, $feedsService, data.localities, $appProperties, $filter, ngTableParams);
+      FeedOverviewCtrl_getFeedSource($scope, $rootScope, $feedsService, data.source);
+      FeedOverviewCtrl_getFeedElection($scope, $rootScope, $feedsService, data.election);
 
     }).error(function (data, $http) {
 
@@ -46,6 +48,8 @@ function FeedOverviewCtrl($scope, $rootScope, $feedsService, $routeParams, $loca
       $scope.feedContests = {};
       $scope.feedLocalities = {};
       $scope.feedCounties = {};
+      $scope.feedSource = {};
+      $scope.feedElection = {};
     });
 }
 
@@ -119,5 +123,56 @@ function FeedOverviewCtrl_getFeedLocalities($scope, $rootScope, $feedsService, s
 
       // so the loading spinner goes away and we are left with an empty table
       $scope.feedLocalities = {};
+    });
+}
+
+/*
+ * Get the Feed Source for the Feed detail page
+ *
+ */
+function FeedOverviewCtrl_getFeedSource($scope, $rootScope, $feedsService, servicePath){
+
+  // get Feed Source
+  $feedsService.getFeedSource(servicePath)
+    .success(function (data) {
+
+      // temporarily sets the percentages for just the overview page
+      data['complete_pct'] = Math.round(Object.keys(data['source_info']).length / 5.0 * 100);
+
+      // set the feeds data into the Angular model
+      $scope.feedSource = data;
+
+    }).error(function (data) {
+
+      $rootScope.pageHeader.error += "Could not retrieve Feed Source. ";
+
+      // so the loading spinner goes away and we are left with an empty table
+      $scope.feedSource = {};
+    });
+}
+
+/*
+ * Get the Feed Election for the Feed detail page
+ *
+ */
+function FeedOverviewCtrl_getFeedElection($scope, $rootScope, $feedsService, servicePath){
+
+  // get Feed Election
+  $feedsService.getFeedElection(servicePath)
+    .success(function (data) {
+
+      // temporarily sets the percentages for just the overview page
+      data['complete_pct'] = Math.round(Object.keys(data).length / 17.0 * 100);
+      data['complete_pct'] = data['complete_pct'] > 100 ? 100 : data['complete_pct']
+      
+      // set the feeds data into the Angular model
+      $scope.feedElection = data;
+
+    }).error(function (data) {
+
+      $rootScope.pageHeader.error += "Could not retrieve Feed Election. ";
+
+      // so the loading spinner goes away and we are left with an empty table
+      $scope.feedElection = {};
     });
 }

--- a/public/assets/js/app/controllers/feedSourceController.js
+++ b/public/assets/js/app/controllers/feedSourceController.js
@@ -85,6 +85,6 @@ function FeedSourceCtrl_getFeedElection($scope, $rootScope, $feedsService, servi
       $rootScope.pageHeader.error += "Could not retrieve Feed Election. ";
 
       // so the loading spinner goes away and we are left with an empty table
-      $scope.feedSource = {};
+      $scope.feedElection = {};
     });
 }

--- a/public/assets/js/app/controllers/feedStateController.js
+++ b/public/assets/js/app/controllers/feedStateController.js
@@ -22,6 +22,8 @@ function FeedStateCtrl($scope, $rootScope, $feedsService, $routeParams, $appProp
 
       // now call the other services to get the rest of the data
       FeedStateCtrl_getFeedState($scope, $rootScope, $feedsService, data.state, $appProperties, $filter, ngTableParams);
+      FeedStateCtrl_getFeedElection($scope, $rootScope, $feedsService, data.election, $appProperties, $filter, ngTableParams);
+      FeedStateCtrl_getFeedPollingLocations($scope, $rootScope, $feedsService, data.polling_locations);
 
     }).error(function (data, $http) {
 
@@ -38,7 +40,8 @@ function FeedStateCtrl($scope, $rootScope, $feedsService, $routeParams, $appProp
       // so the loading spinner goes away and we are left with an empty table
       $scope.feedData = {};
       $scope.feedState = {};
-      $scope.feedEarlyVoteSites = {};
+      $scope.feedElection = {};
+      $scope.feedPollingLocations = {};
       $scope.feedLocalities = {};
     });
 }
@@ -59,46 +62,58 @@ function FeedStateCtrl_getFeedState($scope, $rootScope, $feedsService, servicePa
       // set the title
       $rootScope.pageHeader.title = "State ID: " + data.id;
 
-      FeedStateCtrl_getFeedEarlyVoteSites($scope, $rootScope, $feedsService, data.earlyvotesites, $appProperties, $filter, ngTableParams);
       FeedStateCtrl_getFeedLocalities($scope, $rootScope, $feedsService, data.localities, $appProperties, $filter, ngTableParams);
-      FeedStateCtrl_getFeedCounties($scope, $rootScope, $feedsService, data.county_map);
 
     }).error(function (data) {
 
       $rootScope.pageHeader.error += "Could not retrieve Feed State data. ";
 
       // so the loading spinner goes away and we are left with an empty table
-      $scope.feedState = {};
-      $scope.feedEarlyVoteSites = {};
       $scope.feedLocalities = {};
-      $scope.feedCounties = {};
     });
 }
 
 /*
- * Get the Feed State Early Vote Sites for the Feed detail page
+ * Get the Feed Election for the Feed detail page
  *
  */
-function FeedStateCtrl_getFeedEarlyVoteSites($scope, $rootScope, $feedsService, servicePath, $appProperties, $filter, ngTableParams){
+function FeedStateCtrl_getFeedElection($scope, $rootScope, $feedsService, servicePath, $appProperties, $filter, ngTableParams){
 
-  // get Feed Early Vote Sites
-  $feedsService.getFeedStateEarlyVoteSites(servicePath)
+  // get Feed Election
+  $feedsService.getFeedElection(servicePath)
     .success(function (data) {
 
-      // use the self property to use as the linked URL for each item
-      $rootScope.changeSelfToAngularPath(data);
-
       // set the feeds data into the Angular model
-      $scope.feedEarlyVoteSites = data;
-
-      $scope.earlyVoteTableParams = $rootScope.createTableParams(ngTableParams, $filter, data, $appProperties.lowPagination, { id: 'asc' });
+      $scope.feedElection = data;
 
     }).error(function (data) {
 
-      $rootScope.pageHeader.error += "Could not retrieve State Early Vote Sites. ";
+      $rootScope.pageHeader.error += "Could not retrieve Feed Election Elections. ";
 
       // so the loading spinner goes away and we are left with an empty table
-      $scope.feedEarlyVoteSites = {};
+      $scope.feedElection = {};
+    });
+}
+
+/*
+ * Get the Feed Polling Locations for the Feed Overview page
+ *
+ */
+function FeedStateCtrl_getFeedPollingLocations($scope, $rootScope, $feedsService, servicePath){
+
+  // get Polling Locations
+  $feedsService.getFeedPollingLocations(servicePath)
+    .success(function (data) {
+
+      // set the feeds data into the Angular model
+      $scope.feedPollingLocations = data;
+
+    }).error(function (data) {
+
+      $rootScope.pageHeader.error += "Could not retrieve Feed Polling Locations. ";
+
+      // so the loading spinner goes away and we are left with an empty table
+      $scope.feedPollingLocations = {};
     });
 }
 
@@ -126,30 +141,5 @@ function FeedStateCtrl_getFeedLocalities($scope, $rootScope, $feedsService, serv
 
       // so the loading spinner goes away and we are left with an empty table
       $scope.feedLocalities = {};
-    });
-}
-
-/*
- * Get the Feed Counties (Map) for the Feed State page
- *
- */
-function FeedStateCtrl_getFeedCounties($scope, $rootScope, $feedsService, servicePath){
-
-  // get Results
-  $feedsService.getFeedCounties(servicePath)
-    .success(function (data) {
-
-      // set the feeds data into the Angular model
-      $scope.feedCounties = data;
-
-      // generate the map
-      vipApp_ns.generateMap(data, $rootScope.$appProperties);
-
-    }).error(function (data) {
-
-      $rootScope.pageHeader.error += "Could not retrieve Feed Counties. ";
-
-      // so the loading spinner goes away and we are left with an empty table
-      $scope.feedCounties = {};
     });
 }

--- a/public/test/e2e/feedOverviewTest.js
+++ b/public/test/e2e/feedOverviewTest.js
@@ -42,14 +42,14 @@ describe('Feed Overview Test', function () {
       expect(element('#pollingLocation6').count()).toBe(1);
 
 
-      expect(element('#pollingLocation-element-type0').html()).toBe("Early Vote Sites");
-      expect(element('#pollingLocation-element-type1').html()).toBe("Election Administrations");
-      expect(element('#pollingLocation-element-type2').html()).toBe("Election Officials");
-      expect(element('#pollingLocation-element-type3').html()).toBe("Localities");
-      expect(element('#pollingLocation-element-type4').html()).toBe("Polling Locations");
-      expect(element('#pollingLocation-element-type5').html()).toBe("Precinct Splits");
-      expect(element('#pollingLocation-element-type6').html()).toBe("Precincts");
-      expect(element('#pollingLocation-element-type7').html()).toBe("Street Segments");
+      expect(element('#pollingLocation-element-type0 span').html()).toBe("Early Vote Sites");
+      expect(element('#pollingLocation-element-type1 span').html()).toBe("Election Administrations");
+      expect(element('#pollingLocation-element-type2 span').html()).toBe("Election Officials");
+      expect(element('#pollingLocation-element-type3 span').html()).toBe("Localities");
+      expect(element('#pollingLocation-element-type4 span').html()).toBe("Polling Locations");
+      expect(element('#pollingLocation-element-type5 span').html()).toBe("Precinct Splits");
+      expect(element('#pollingLocation-element-type6 span').html()).toBe("Precincts");
+      expect(element('#pollingLocation-element-type7 span').html()).toBe("Street Segments");
     });
 
   });
@@ -61,7 +61,7 @@ describe('Feed Overview Test', function () {
     // check the the number of items
     it('Should have localities', function () {
 
-      expect(element('#LocalTable').count()).toBe(1);
+      expect(element('#localTable').count()).toBe(1);
       expect(element('#locality0').count()).toBe(1);
     });
 

--- a/public/test/e2e/feedOverviewTest.js
+++ b/public/test/e2e/feedOverviewTest.js
@@ -80,6 +80,21 @@ describe('Feed Overview Test', function () {
   });
 
   /* ----------------------------------------
+   Feed Overview Source & Election
+   ------------------------------------------*/
+  describe('Check Feed Source & Election', function () {
+    // check the the number of items
+    it('Should have source results', function () {
+      expect(element('#feedSource').count()).toBe(1);
+    });
+
+    it('Should have election results', function () {
+      expect(element('#feedElection').count()).toBe(1);
+    });
+  });
+
+
+  /* ----------------------------------------
    Feed Sidebar
    ------------------------------------------*/
   describe('Check Feed Sidebar', function () {

--- a/public/test/e2e/feedOverviewTest.js
+++ b/public/test/e2e/feedOverviewTest.js
@@ -55,6 +55,19 @@ describe('Feed Overview Test', function () {
   });
 
   /* ----------------------------------------
+   Feed Overview Localities
+   ------------------------------------------*/
+  describe('Check Feed Overview localities', function () {
+    // check the the number of items
+    it('Should have localities', function () {
+
+      expect(element('#LocalTable').count()).toBe(1);
+      expect(element('#locality0').count()).toBe(1);
+    });
+
+  });
+
+  /* ----------------------------------------
    Feed Overview Contests
    ------------------------------------------*/
   describe('Check Feed Contests', function () {

--- a/public/test/e2e/feedStateTest.js
+++ b/public/test/e2e/feedStateTest.js
@@ -59,9 +59,15 @@ describe('Feed State Test', function () {
    ------------------------------------------*/
   describe('Check Feed State data', function () {
     // if there is data
-    it('Should have Early Vote Sites data', function () {
+    it('Should have State data', function () {
 
-      expect(element('#earlyVoteSite0').count()).toBe(1);
+      expect(element('#state-id').count()).toBe(1);
+    });
+
+    // if there is data
+    it('Should have Polling Location data', function () {
+
+      expect(element('#pollingLocation0').count()).toBe(1);
     });
 
     // if there is data
@@ -87,6 +93,31 @@ describe('Feed State Test', function () {
 
       expect(element('#feed-state-content').count()).toBe(1);
     })
+  });
+
+  /* ----------------------------------------
+   Feed Overview Polling Locations
+   ------------------------------------------*/
+  describe('Check Feed Overview polling locations', function () {
+    // check the the number of items
+    it('Should have polling locations', function () {
+
+      // let's make sure we have the various sections available in the polling locations section
+      expect(element('#pollingLocation0').count()).toBe(1);
+      //...
+      expect(element('#pollingLocation6').count()).toBe(1);
+
+
+      expect(element('#pollingLocation-element-type0').html()).toBe("Early Vote Sites");
+      expect(element('#pollingLocation-element-type1').html()).toBe("Election Administrations");
+      expect(element('#pollingLocation-element-type2').html()).toBe("Election Officials");
+      expect(element('#pollingLocation-element-type3').html()).toBe("Localities");
+      expect(element('#pollingLocation-element-type4').html()).toBe("Polling Locations");
+      expect(element('#pollingLocation-element-type5').html()).toBe("Precinct Splits");
+      expect(element('#pollingLocation-element-type6').html()).toBe("Precincts");
+      expect(element('#pollingLocation-element-type7').html()).toBe("Street Segments");
+    });
+
   });
 
   /* ----------------------------------------
@@ -147,68 +178,51 @@ describe('Feed State Test', function () {
   });
 
   /* ----------------------------------------
-   Feed State Early Vote Site page
+   Feed State Localities page
    ------------------------------------------*/
-  describe('Check Feed State Early Vote Site page', function () {
-    // if there is data
-    it('Should be able to go into a State Early Vote Site page', function () {
+  describe('Check Feed State Localities page', function () {
+    // check the the number of items
+    it('Should go to the Localities page', function () {
 
-      expect(element('#earlyVoteSite-id0 a').count()).toBe(1);
-      element('#earlyVoteSite-id0 a').click();
+      expect(element('#locality-id0').count()).toBe(1);
+      // click the state link
+      element('#locality-id0 a').click();
       sleep(testGlobals.sleepTime);
 
-      // should be on the feed state early vote site page
-      expect(element('#feeds-election-state-earlyvotesites-content-single').count()).toBe(1);
+      // should be on the feed state election administration page
+      expect(element('#feed-locality-content').count()).toBe(1);
     });
 
-    // if there is data
-    it('Should have Early Vote Site data', function () {
+    // go back to state page
+    it('Should be able to go back to the State page via the breadcrumbs', function () {
 
-      expect(element('#name').html()).not().toBe("");
-    });
-
-  });
-
-  describe('Check error page link', function() {
-    it('Error page link works', function() {
-      element('#earlyvotesite-errors').click();
+      // now go back to the state page
+      // click the state breadcrumb
+      element('#pageHeader-breadcrumb3 a').click();
       sleep(testGlobals.sleepTime);
-      expect(element('#feeds-election-state-earlyvotesites-errors-content').count()).toBe(1);
-      element('#pageHeader-breadcrumb5 a').click();
-      expect(element('#feeds-election-state-earlyvotesites-content-single').count()).toBe(1);
+
+      // should be on the feed state page
+      expect(element('#feed-state-content').count()).toBe(1);
     });
+
   });
 
   /* ----------------------------------------
-   Feed State Early Vote Sites page
+   Feed State Polling Locations page
    ------------------------------------------*/
-  describe('Check Feed State Early Vote Sites page', function () {
-    // if there is data
-    it('Should be able to go into a State Early Vote Sites page via breadcrumbs', function () {
+  describe('Check Feed State Polling Locations page', function () {
+    // check the the number of items
+    it('Should go to the Polling Locations error page', function () {
 
-      element('#pageHeader-breadcrumb4 a').click();
+      expect(element('#pollingLocation-errors0').count()).toBe(1);
+      // click the state link
+      element('#pollingLocation-errors0 a').click();
       sleep(testGlobals.sleepTime);
 
-      // should be on the feed state early vote sites page
-      expect(element('#feeds-election-state-earlyvotesites-content').count()).toBe(1);
+      // should be on the feed state election administration page
+      expect(element('#feeds-overview-earlyvotesites-errors-content').count()).toBe(1);
     });
 
-    // if there is data
-    it('Should have Early Vote Sites data', function () {
-
-      expect(element('#earlyVoteSite-id0 a').html()).not().toBe("");
-
-    });
-
-    // click to an earlyvote site
-    it('Should be able to click on the link and be taken back to an Early Vote Site page', function () {
-
-      element('#earlyVoteSite-id0 a').click();
-      sleep(testGlobals.sleepTime);
-
-      // should be on the feed state early vote site page
-      expect(element('#feeds-election-state-earlyvotesites-content-single').count()).toBe(1);
-    });
   });
 
   /* ----------------------------------------


### PR DESCRIPTION
This PR addresses changes to the front-end of Metis, in the following ways:

* [Pivotal Card 93958240](https://www.pivotaltracker.com/story/show/93958240): Replace locality maps with paginated lists
* [Pivotal Card 93949614](https://www.pivotaltracker.com/story/show/93949614): Reorganize Polling Location/State Page
* [Pivotal Card 93958218](https://www.pivotaltracker.com/story/show/93958218): Tables on the VIP Feed "Overview" page should all be sortable, including the completion column
* [Pivotal Card 93948506](https://www.pivotaltracker.com/story/show/93948506): Create Source & Election Error Overview table and remove existing Results table

Assigned @tie-rack.