### PR TITLE
Front end updates 5

### DIFF
--- a/public/app/partials/aside.html
+++ b/public/app/partials/aside.html
@@ -22,8 +22,8 @@
 
     <nav class="feed-nav">
       <ul>
-        <li><a id="sidebar-source" class="is-finished" href="{{getAngularUrl(feedData.source)}}">Source &amp; Election</a></li>
         <li><a id="sidebar-overview" class="is-finished" href="{{getAngularUrl(feedData.overview)}}">Overview</a></li>
+        <li><a id="sidebar-source" class="is-finished" href="{{getAngularUrl(feedData.source)}}">Source &amp; Election</a></li>
         <li><a id="sidebar-pollinglocations" class="is-started" href="{{getAngularUrl(feedData.state)}}">Polling Locations</a></li>
         <li><a id="sidebar-contests" class="is-started" href="{{getAngularUrl(feedData.election_contests)}}">Contests</a></li>
         <li><a id="sidebar-errors" class="is-started" href="{{getAngularUrl(feedData.errors)}}">Errors</a></li>

--- a/public/app/partials/aside.html
+++ b/public/app/partials/aside.html
@@ -23,7 +23,7 @@
     <nav class="feed-nav">
       <ul>
         <li><a id="sidebar-source" class="is-finished" href="{{getAngularUrl(feedData.source)}}">Source</a></li>
-        <li><a id="sidebar-election" class="is-finished" href="{{getAngularUrl(feedData.election)}}">Election</a></li>
+        <li><a id="sidebar-overview" class="is-finished" href="{{getAngularUrl(feedData.overview)}}">Overview</a></li>
         <li><a id="sidebar-pollinglocations" class="is-started" href="{{getAngularUrl(feedData.state)}}">Polling Locations</a></li>
         <li><a id="sidebar-contests" class="is-started" href="{{getAngularUrl(feedData.election_contests)}}">Contests</a></li>
         <li><a id="sidebar-errors" class="is-started" href="{{getAngularUrl(feedData.errors)}}">Errors</a></li>

--- a/public/app/partials/aside.html
+++ b/public/app/partials/aside.html
@@ -22,7 +22,7 @@
 
     <nav class="feed-nav">
       <ul>
-        <li><a id="sidebar-source" class="is-finished" href="{{getAngularUrl(feedData.source)}}">Source</a></li>
+        <li><a id="sidebar-source" class="is-finished" href="{{getAngularUrl(feedData.source)}}">Source &amp; Election</a></li>
         <li><a id="sidebar-overview" class="is-finished" href="{{getAngularUrl(feedData.overview)}}">Overview</a></li>
         <li><a id="sidebar-pollinglocations" class="is-started" href="{{getAngularUrl(feedData.state)}}">Polling Locations</a></li>
         <li><a id="sidebar-contests" class="is-started" href="{{getAngularUrl(feedData.election_contests)}}">Contests</a></li>

--- a/public/app/partials/feed-candidate.html
+++ b/public/app/partials/feed-candidate.html
@@ -8,8 +8,6 @@
 <div class="data-module-full">
   <dl class="attributes" ng-if="feedCandidate">
     <dt class="key">Name:</dt> <dd id="candidate-name" class="value">{{feedCandidate.name}}</dd>
-    <dt class="key">Last Name:</dt> <dd id="candidate-lastname" class="value">{{feedCandidate.last_name}}</dd>
-    <dt class="key">Incumbent:</dt> <dd id="candidate-incumbent" class="value">{{feedCandidate.incumbent}}</dd>
 
     <!-- Logic to switch detailed party -->
     <dt class="key" ng-if="!feedCandidate.party.name">Party:</dt>
@@ -36,8 +34,6 @@
 
     <dt class="key">Email:</dt> <dd id="candidate-email" class="value">{{feedCandidate.email}}</dd>
     <dt class="key">Sort Order:</dt> <dd id="candidate-sortorder" class="value">{{feedCandidate.sort_order}}</dd>
-    <dt class="key">Incumbent:</dt> <dd id="candidate-incumbent" class="value">{{feedCandidate.incumbent}}</dd>
-    <dt class="key">Candidate Status:</dt> <dd id="candidate-status" class="value">{{feedCandidate.candidate_status}}</dd>
   </dl>
 
   <section class="data-group data-module">
@@ -66,4 +62,3 @@
   </section>
 
 </div>
-

--- a/public/app/partials/feed-overview.html
+++ b/public/app/partials/feed-overview.html
@@ -75,7 +75,6 @@
   <!-- element table directive -->
   <section class="data-group data-module">
     <div ng-if="!feedLocalities"></br><span class="is-loading"></span></div>
-    {{localTableParams}}
     <table ng-show="feedLocalities.length" id="localTable" ng-table="localTableParams" template-pagination="localPagination" class="associations">
       <tr id="locality{{$index}}" ng-repeat="locality in $data">
         <td id="locality-id{{$index}}" class="id" data-title="'ID'" sortable="'id'">

--- a/public/app/partials/feed-state.html
+++ b/public/app/partials/feed-state.html
@@ -12,6 +12,7 @@
       <th>ID</th>
       <th>Name</th>
       <th>Localities</th>
+      <th class="numeric">Errors</th>
     </tr>
     </thead>
     <tbody>
@@ -19,6 +20,9 @@
       <td id="state-id" class="id"><a href="{{$location.absUrl()}}" data-title-text="ID"><span class="td-text">{{feedElection.state.id}}</span></a></td>
       <td id="state-name" class="name"><a href="{{$location.absUrl()}}" data-title-text="Name"><span class="td-text">{{feedElection.state.name}}</span></a></td>
       <td id="state-localities" class="localities"><a href="{{$location.absUrl()}}" data-title-text="Localities"><span class="td-text">{{feedElection.state.locality_count}}</span></a>
+      </td>
+      <td data-title="'Errors'" sortable="'error_count'" id="feedContests-errors{{$index}}" class="numeric element-errors">
+       <p ng-if="feedState.error_count !== undefined" data-title-text="Errors"><a id="state-errors" class="error-count error-count-{{feedState.error_count}}" href="{{$location.absUrl()}}/errors">{{feedState.error_count}}<span ng-if="feedState.error_count===0"><i class="fi-check"></i></span><span ng-if="feedState.error_count!=0"><i class="fi-alert"></i></span></a></p>
       </td>
     </tr>
     </tbody>
@@ -89,4 +93,3 @@
     </ul>
   </script>
 </section>
-

--- a/public/app/partials/feed-state.html
+++ b/public/app/partials/feed-state.html
@@ -1,7 +1,5 @@
 <i id="feed-state-content"></i>
 
-<p ng-if="feedState.error_count !== undefined"><a id="state-errors" class="error-count error-count-{{feedState.error_count}}" href="{{$location.absUrl()}}/errors">{{feedState.error_count}} Errors in State ID: {{feedState.id}}</a></p>
-
 <section class="data-group data-module">
   <h2>State</h2>
 

--- a/public/assets/css/module.scss
+++ b/public/assets/css/module.scss
@@ -133,11 +133,22 @@
           color: $white;
         }
       }
+      td.numeric {
+       padding: 1em 1em 0 0;
+       @include max-bp(c6) {
+        border-top: 1px solid #33699c;
+        padding: .5em 1em .5em 0;
+       }
+
+       p {
+        margin: 0;
+       }
+      }
     }
   }
 
   a {
-    display: block; 
+    display: block;
     line-height: 1.125;
     padding: $base-sm $base;
     @include clearfix;
@@ -186,7 +197,32 @@
     @include bp(c6) {
       border: none;
     }
-    
+
+  }
+  p {
+   &:before {
+     content: attr(data-title-text);
+     width: 47%;
+     display: block;
+     float: left;
+     font-weight: bold;
+     font-size: 0.875em;
+     font-size: 0.875rem;
+     line-height: 1.3;
+     margin-top: $base-xs;
+     text-transform: uppercase;
+     letter-spacing: 1px;
+     padding-right: 3%;
+
+     @include bp(c6) {
+       content: '';
+     }
+   }
+   @include max-bp(c6) {
+    padding-left: 1em;
+   }
+
+
   }
 
   td {
@@ -207,6 +243,50 @@
     padding-left: 1em;
   }
 
+  .error-count {
+    color: $white;
+    font-weight: bold;
+    padding: 0.1875em 0.375em 0.25em 0.625em;
+    display: inline-block;
+    margin: 0 $base-sm $base;
+    background: $red;
+    border-radius: 15px;
+    text-align: left;
+
+    @include bp(c6) {
+      margin-left: 0;
+      margin-right: 0;
+    }
+
+    @include max-bp(c6) {
+     margin: 0 0 0 -0.5em;
+    }
+
+
+    &:hover, &:focus {
+      background: #f33;
+      color: $white;
+    }
+  }
+  .fi-check {
+    color: #063;
+    margin: 0 0 0 $base-sm;
+  }
+
+  .fi-alert {
+    color: #600;
+  }
+  .error-count-0 {
+    background-color: $green;
+    &:hover, &:focus {
+      background-color: $green;
+    }
+  }
+  .error-count-1, .errors {
+    &:after {
+     color: #600;
+    }
+  }
 }
 
 .associations-end {

--- a/public/assets/js/app/app.js
+++ b/public/assets/js/app/app.js
@@ -560,10 +560,13 @@ vipApp.run(function ($rootScope, $appService, $location, $httpBackend, $appPrope
 
     var pathTokens = path.split("/");
 
+    // Since we want to eliminate the "Feeds" link from the breadcrumb path, we start off at /#/feeds and increment the for loop from 1 instead of 0
+
     var url = "/#/feeds";
     var name = null;
 
     var makeUrlNull = false;
+
     for(var index=1; index<pathTokens.length; index++){
 
       name = pathTokens[index];

--- a/public/assets/js/app/app.js
+++ b/public/assets/js/app/app.js
@@ -584,6 +584,11 @@ vipApp.run(function ($rootScope, $appService, $location, $httpBackend, $appPrope
         url = null;
       }
 
+      if(name === "source"){
+        name = "source & election";
+        url = null;
+      }
+
       if(name === "electionadministration"){
         name = "election administration";
       }

--- a/public/assets/js/app/app.js
+++ b/public/assets/js/app/app.js
@@ -560,11 +560,11 @@ vipApp.run(function ($rootScope, $appService, $location, $httpBackend, $appPrope
 
     var pathTokens = path.split("/");
 
-    var url = "/#";
+    var url = "/#/feeds";
     var name = null;
 
     var makeUrlNull = false;
-    for(var index=0; index<pathTokens.length; index++){
+    for(var index=1; index<pathTokens.length; index++){
 
       name = pathTokens[index];
       url += "/" + pathTokens[index];

--- a/public/assets/js/app/controllers/feedContestsController.js
+++ b/public/assets/js/app/controllers/feedContestsController.js
@@ -56,7 +56,7 @@ function FeedContestsCtrl_getFeedContests($scope, $rootScope, $feedsService, ser
       $scope.contestsTableParams = $rootScope.createTableParams(ngTableParams, $filter, data, $appProperties.highPagination, { id: 'asc' });
 
       // set the title
-      $rootScope.pageHeader.title = $scope.feedContests.length + " Contests";
+      $rootScope.pageHeader.title = "Contests";
     }).error(function(data, $http) {
       $rootScope.pageHeader.error += "Could not retrieve Feed Contests data. ";
 
@@ -78,7 +78,7 @@ function FeedContestsOverviewCtrl_getFeedContestsOverview($scope, $rootScope, $f
       $scope.contestsTableParams = $rootScope.createTableParams(ngTableParams, $filter, data, $appProperties.highPagination, { id: 'asc' });
 
       // set the title
-      $rootScope.pageHeader.title = $scope.feedContests.length + " Contests";
+      $rootScope.pageHeader.title = "Contests";
     }).error(function(data, $http) {
       $rootScope.pageHeader.error += "Could not retrieve Feed Contests data. ";
 

--- a/public/assets/js/app/controllers/feedSourceController.js
+++ b/public/assets/js/app/controllers/feedSourceController.js
@@ -10,7 +10,7 @@ function FeedSourceCtrl($scope, $rootScope, $feedsService, $routeParams, $locati
   $scope.vipfeed = $routeParams.vipfeed;
 
   // initialize page header variables
-  $rootScope.setPageHeader("Source", $rootScope.getBreadCrumbs(), "feeds", "" ,null);
+  $rootScope.setPageHeader("Source & Election", $rootScope.getBreadCrumbs(), "feeds", "" ,null);
 
   // get general Feed data
   $feedsService.getFeedData(feedid)
@@ -56,7 +56,7 @@ function FeedSourceCtrl_getFeedSource($scope, $rootScope, $feedsService, service
       $scope.feedSource = data;
 
       // set the title
-      $rootScope.pageHeader.title = "Source ID: " + data.id;
+      $rootScope.pageHeader.title = "Source & Election ID: " + data.id;
 
     }).error(function (data) {
 

--- a/public/assets/js/app/controllers/feedStateController.js
+++ b/public/assets/js/app/controllers/feedStateController.js
@@ -60,7 +60,7 @@ function FeedStateCtrl_getFeedState($scope, $rootScope, $feedsService, servicePa
       $scope.feedState = data;
 
       // set the title
-      $rootScope.pageHeader.title = "State ID: " + data.id;
+      $rootScope.pageHeader.title = "Polling Locations";
 
       FeedStateCtrl_getFeedLocalities($scope, $rootScope, $feedsService, data.localities, $appProperties, $filter, ngTableParams);
 

--- a/public/assets/js/app/controllers/feedStateController.js
+++ b/public/assets/js/app/controllers/feedStateController.js
@@ -10,7 +10,7 @@ function FeedStateCtrl($scope, $rootScope, $feedsService, $routeParams, $appProp
   $scope.vipfeed = feedid;
 
   // initialize page header variables
-  $rootScope.setPageHeader("State", $rootScope.getBreadCrumbs(), "feeds", "", null);
+  $rootScope.setPageHeader("Polling Locations", $rootScope.getBreadCrumbs(), "feeds", "", null);
 
   // get general Feed data
   $feedsService.getFeedData(feedid)

--- a/public/test/e2e/breadcrumbsTest.js
+++ b/public/test/e2e/breadcrumbsTest.js
@@ -80,7 +80,7 @@ describe('Breadcrumbs Test', function () {
 
       expect(element('#pageHeader-breadcrumb0 a').html()).toBe("Feeds");
       expect(element('#pageHeader-breadcrumb1 a').html()).toBe("vip-feed1");
-      expect(element('#pageHeader-breadcrumb2 a').html()).toBe("Source");
+      expect(element('#pageHeader-breadcrumb2 a').html()).toBe("Source & Election");
 
     });
   });

--- a/public/test/e2e/feedBallotLineResultTest.js
+++ b/public/test/e2e/feedBallotLineResultTest.js
@@ -28,14 +28,14 @@ describe('Testing Feed Ballot Line Result Page', function() {
        sleep(testGlobals.sleepTime);
        */
 
-      expect(element('#sidebar-election').count()).toBe(1);
+      expect(element('#sidebar-contests').count()).toBe(1);
 
-      // click the election link
-      element('#sidebar-election').click();
+      // click the contests link
+      element('#sidebar-contests').click();
       sleep(testGlobals.sleepTime);
 
       // should be on the feed election page
-      expect(element('#feed-election-content').count()).toBe(1);
+      expect(element('#feed-contests-content').count()).toBe(1);
 
       element('#contests-id0 a').click();
 

--- a/public/test/e2e/feedBallotLineResultsTest.js
+++ b/public/test/e2e/feedBallotLineResultsTest.js
@@ -28,14 +28,14 @@ describe('Testing Feed Ballot Line Results Page', function() {
        sleep(testGlobals.sleepTime);
        */
 
-      expect(element('#sidebar-election').count()).toBe(1);
+      expect(element('#sidebar-contests').count()).toBe(1);
 
-      // click the election link
-      element('#sidebar-election').click();
+      // click the contests link
+      element('#sidebar-contests').click();
       sleep(testGlobals.sleepTime);
 
       // should be on the feed election page
-      expect(element('#feed-election-content').count()).toBe(1);
+      expect(element('#feed-contests-content').count()).toBe(1);
 
       element('#contests-id0 a').click();
 

--- a/public/test/e2e/feedBallotTest.js
+++ b/public/test/e2e/feedBallotTest.js
@@ -23,19 +23,19 @@ describe('Testing Feed Ballot Page', function() {
       /*
        expect(element('#election-link').count()).toBe(1);
 
-       // click the election link
+       // click the contests link
        element('#election-link').click();
        sleep(testGlobals.sleepTime);
        */
 
-      expect(element('#sidebar-election').count()).toBe(1);
+      expect(element('#sidebar-contests').count()).toBe(1);
 
-      // click the election link
-      element('#sidebar-election').click();
+      // click the contests link
+      element('#sidebar-contests').click();
       sleep(testGlobals.sleepTime);
 
       // should be on the feed election page
-      expect(element('#feed-election-content').count()).toBe(1);
+      expect(element('#feed-contests-content').count()).toBe(1);
 
       element('#contests-id0 a').click();
 

--- a/public/test/e2e/feedCandidateTest.js
+++ b/public/test/e2e/feedCandidateTest.js
@@ -28,14 +28,14 @@ describe('Testing Feed Candidate Page', function() {
        sleep(testGlobals.sleepTime);
        */
 
-      expect(element('#sidebar-election').count()).toBe(1);
+      expect(element('#sidebar-contests').count()).toBe(1);
 
-      // click the election link
-      element('#sidebar-election').click();
+      // click the contests link
+      element('#sidebar-contests').click();
       sleep(testGlobals.sleepTime);
 
-      // should be on the feed election page
-      expect(element('#feed-election-content').count()).toBe(1);
+      // should be on the feed contests page
+      expect(element('#feed-contests-content').count()).toBe(1);
 
       element('#contests-id0 a').click();
       expect(element('#feed-contest-content').count()).toBe(1);
@@ -99,14 +99,14 @@ describe('Testing Feed Candidates Page', function() {
        sleep(testGlobals.sleepTime);
        */
 
-      expect(element('#sidebar-election').count()).toBe(1);
+      expect(element('#sidebar-contests').count()).toBe(1);
 
-      // click the election link
-      element('#sidebar-election').click();
+      // click the contests link
+      element('#sidebar-contests').click();
       sleep(testGlobals.sleepTime);
 
       // should be on the feed election page
-      expect(element('#feed-election-content').count()).toBe(1);
+      expect(element('#feed-contests-content').count()).toBe(1);
 
       element('#contests-id0 a').click();
       expect(element('#feed-contest-content').count()).toBe(1);
@@ -137,4 +137,3 @@ describe('Testing Feed Candidates Page', function() {
     });
   });
 });
-

--- a/public/test/e2e/feedContestResultTest.js
+++ b/public/test/e2e/feedContestResultTest.js
@@ -28,14 +28,14 @@ describe('Testing Feed Contest Results Page', function() {
        sleep(testGlobals.sleepTime);
        */
 
-      expect(element('#sidebar-election').count()).toBe(1);
+      expect(element('#sidebar-contests').count()).toBe(1);
 
-      // click the election link
-      element('#sidebar-election').click();
+      // click the contests link
+      element('#sidebar-contests').click();
       sleep(testGlobals.sleepTime);
 
-      // should be on the feed election page
-      expect(element('#feed-election-content').count()).toBe(1);
+      // should be on the feed contests page
+      expect(element('#feed-contests-content').count()).toBe(1);
 
       element('#contests-id0 a').click();
 

--- a/public/test/e2e/feedContestTest.js
+++ b/public/test/e2e/feedContestTest.js
@@ -28,14 +28,14 @@ describe('Testing Feed Contest Page', function() {
        sleep(testGlobals.sleepTime);
        */
 
-      expect(element('#sidebar-election').count()).toBe(1);
+      expect(element('#sidebar-contests').count()).toBe(1);
 
-      // click the election link
-      element('#sidebar-election').click();
+      // click the contests link
+      element('#sidebar-contests').click();
       sleep(testGlobals.sleepTime);
 
-      // should be on the feed election page
-      expect(element('#feed-election-content').count()).toBe(1);
+      // should be on the feed contests page
+      expect(element('#feed-contests-content').count()).toBe(1);
 
       element('#contests-id0 a').click();
 
@@ -172,14 +172,14 @@ describe('Testing Feed Contests Page', function() {
        sleep(testGlobals.sleepTime);
        */
 
-      expect(element('#sidebar-election').count()).toBe(1);
+      expect(element('#sidebar-contests').count()).toBe(1);
 
-      // click the election link
-      element('#sidebar-election').click();
+      // click the contests link
+      element('#sidebar-contests').click();
       sleep(testGlobals.sleepTime);
 
-      // should be on the feed election page
-      expect(element('#feed-election-content').count()).toBe(1);
+      // should be on the feed contests page
+      expect(element('#feed-contests-content').count()).toBe(1);
 
       element('#contests-id0 a').click();
 

--- a/public/test/e2e/feedElectionTest.js
+++ b/public/test/e2e/feedElectionTest.js
@@ -29,10 +29,10 @@ describe('Feed Election Test', function () {
       sleep(testGlobals.sleepTime);
       */
 
-      expect(element('#sidebar-election').count()).toBe(1);
+      expect(element('#sidebar-source').count()).toBe(1);
 
-      // click the election link
-      element('#sidebar-election').click();
+      // click the source link
+      element('#sidebar-source').click();
       sleep(testGlobals.sleepTime);
 
       // should be on the feed Source page

--- a/public/test/e2e/feedLocalitiesTest.js
+++ b/public/test/e2e/feedLocalitiesTest.js
@@ -22,21 +22,27 @@ describe('Feed Localities Test', function () {
       sleep(testGlobals.sleepTime);
 
       /*
-       expect(element('#election-link').count()).toBe(1);
-
-       // click the election link
-       element('#election-link').click();
-       sleep(testGlobals.sleepTime);
-       */
-
-      expect(element('#sidebar-election').count()).toBe(1);
+      expect(element('#election-link').count()).toBe(1);
 
       // click the election link
-      element('#sidebar-election').click();
+      element('#election-link').click();
+      sleep(testGlobals.sleepTime);
+      */
+
+      expect(element('#sidebar-contests').count()).toBe(1);
+
+      // click the contests link
+      element('#sidebar-contests').click();
       sleep(testGlobals.sleepTime);
 
+      // should be on the feed contests page
+      expect(element('#feed-contests-content').count()).toBe(1);
+
+      // should have a link back to the election page in the breadcrumbs
+      expect(element('#pageHeader-breadcrumb2').count()).toBe(1);
+      element('#pageHeader-breadcrumb2').click();
+
       // should be on the feed election page
-      expect(element('#feed-election-content').count()).toBe(1);
 
       // should have a state link
       expect(element('#state-id a').count()).toBe(1);

--- a/public/test/e2e/feedLocalityTest.js
+++ b/public/test/e2e/feedLocalityTest.js
@@ -29,14 +29,20 @@ describe('Feed Locality Test', function () {
        sleep(testGlobals.sleepTime);
        */
 
-      expect(element('#sidebar-election').count()).toBe(1);
+      expect(element('#sidebar-contests').count()).toBe(1);
 
-      // click the election link
-      element('#sidebar-election').click();
+      // click the contests link
+      element('#sidebar-contests').click();
       sleep(testGlobals.sleepTime);
 
+      // should be on the feed contests page
+      expect(element('#feed-contests-content').count()).toBe(1);
+
+      // should have a link back to the election page in the breadcrumbs
+      expect(element('#pageHeader-breadcrumb2').count()).toBe(1);
+      element('#pageHeader-breadcrumb2').click();
+
       // should be on the feed election page
-      expect(element('#feed-election-content').count()).toBe(1);
 
       // should have a state link
       expect(element('#state-id a').count()).toBe(1);

--- a/public/test/e2e/feedPrecinctSplitTest.js
+++ b/public/test/e2e/feedPrecinctSplitTest.js
@@ -29,14 +29,20 @@ describe('Feed Precinct Split Test', function () {
        sleep(testGlobals.sleepTime);
        */
 
-      expect(element('#sidebar-election').count()).toBe(1);
+      expect(element('#sidebar-contests').count()).toBe(1);
 
-      // click the election link
-      element('#sidebar-election').click();
+      // click the contests link
+      element('#sidebar-contests').click();
       sleep(testGlobals.sleepTime);
 
+      // should be on the feed contests page
+      expect(element('#feed-contests-content').count()).toBe(1);
+
+      // should have a link back to the election page in the breadcrumbs
+      expect(element('#pageHeader-breadcrumb2').count()).toBe(1);
+      element('#pageHeader-breadcrumb2').click();
+
       // should be on the feed election page
-      expect(element('#feed-election-content').count()).toBe(1);
 
       // should have a state link
       expect(element('#state-id a').count()).toBe(1);

--- a/public/test/e2e/feedPrecinctSplitsTest.js
+++ b/public/test/e2e/feedPrecinctSplitsTest.js
@@ -29,14 +29,20 @@ describe('Feed Precinct Splits Test', function () {
        sleep(testGlobals.sleepTime);
        */
 
-      expect(element('#sidebar-election').count()).toBe(1);
+      expect(element('#sidebar-contests').count()).toBe(1);
 
-      // click the election link
-      element('#sidebar-election').click();
+      // click the contests link
+      element('#sidebar-contests').click();
       sleep(testGlobals.sleepTime);
 
+      // should be on the feed contests page
+      expect(element('#feed-contests-content').count()).toBe(1);
+
+      // should have a link back to the election page in the breadcrumbs
+      expect(element('#pageHeader-breadcrumb2').count()).toBe(1);
+      element('#pageHeader-breadcrumb2').click();
+
       // should be on the feed election page
-      expect(element('#feed-election-content').count()).toBe(1);
 
       // should have a state link
       expect(element('#state-id a').count()).toBe(1);

--- a/public/test/e2e/feedPrecinctTest.js
+++ b/public/test/e2e/feedPrecinctTest.js
@@ -29,14 +29,20 @@ describe('Feed Precinct Test', function () {
        sleep(testGlobals.sleepTime);
        */
 
-      expect(element('#sidebar-election').count()).toBe(1);
+      expect(element('#sidebar-contests').count()).toBe(1);
 
-      // click the election link
-      element('#sidebar-election').click();
+      // click the contests link
+      element('#sidebar-contests').click();
       sleep(testGlobals.sleepTime);
 
+      // should be on the feed contests page
+      expect(element('#feed-contests-content').count()).toBe(1);
+
+      // should have a link back to the election page in the breadcrumbs
+      expect(element('#pageHeader-breadcrumb2').count()).toBe(1);
+      element('#pageHeader-breadcrumb2').click();
+
       // should be on the feed election page
-      expect(element('#feed-election-content').count()).toBe(1);
 
       // should have a state link
       expect(element('#state-id a').count()).toBe(1);

--- a/public/test/e2e/feedPrecinctsTest.js
+++ b/public/test/e2e/feedPrecinctsTest.js
@@ -29,14 +29,20 @@ describe('Feed Precincts Test', function () {
        sleep(testGlobals.sleepTime);
        */
 
-      expect(element('#sidebar-election').count()).toBe(1);
+      expect(element('#sidebar-contests').count()).toBe(1);
 
-      // click the election link
-      element('#sidebar-election').click();
+      // click the contests link
+      element('#sidebar-contests').click();
       sleep(testGlobals.sleepTime);
 
+      // should be on the feed contests page
+      expect(element('#feed-contests-content').count()).toBe(1);
+
+      // should have a link back to the election page in the breadcrumbs
+      expect(element('#pageHeader-breadcrumb2').count()).toBe(1);
+      element('#pageHeader-breadcrumb2').click();
+
       // should be on the feed election page
-      expect(element('#feed-election-content').count()).toBe(1);
 
       // should have a state link
       expect(element('#state-id a').count()).toBe(1);

--- a/public/test/e2e/feedReferendumTest.js
+++ b/public/test/e2e/feedReferendumTest.js
@@ -28,14 +28,14 @@ describe('Testing Feed Referendum Page', function() {
        sleep(testGlobals.sleepTime);
        */
 
-      expect(element('#sidebar-election').count()).toBe(1);
+      expect(element('#sidebar-contests').count()).toBe(1);
 
-      // click the election link
-      element('#sidebar-election').click();
+      // click the contests link
+      element('#sidebar-contests').click();
       sleep(testGlobals.sleepTime);
 
       // should be on the feed election page
-      expect(element('#feed-election-content').count()).toBe(1);
+      expect(element('#feed-contests-content').count()).toBe(1);
 
       element('#contests-id0 a').click();
       expect(element('#feed-contest-content').count()).toBe(1);
@@ -104,14 +104,14 @@ describe('Testing Feed Referenda Page', function() {
        sleep(testGlobals.sleepTime);
        */
 
-      expect(element('#sidebar-election').count()).toBe(1);
+      expect(element('#sidebar-contests').count()).toBe(1);
 
-      // click the election link
-      element('#sidebar-election').click();
+      // click the contests link
+      element('#sidebar-contests').click();
       sleep(testGlobals.sleepTime);
 
-      // should be on the feed election page
-      expect(element('#feed-election-content').count()).toBe(1);
+      // should be on the feed contests page
+      expect(element('#feed-contests-content').count()).toBe(1);
 
       element('#contests-id0 a').click();
       expect(element('#feed-contest-content').count()).toBe(1);

--- a/public/test/e2e/feedStateTest.js
+++ b/public/test/e2e/feedStateTest.js
@@ -29,16 +29,20 @@ describe('Feed State Test', function () {
        sleep(testGlobals.sleepTime);
        */
 
-      expect(element('#sidebar-election').count()).toBe(1);
+      expect(element('#sidebar-contests').count()).toBe(1);
 
-      // click the election link
-      element('#sidebar-election').click();
+      // click the contests link
+      element('#sidebar-contests').click();
       sleep(testGlobals.sleepTime);
 
+      // should be on the feed contests page
+      expect(element('#feed-contests-content').count()).toBe(1);
 
+      // should have a link back to the election page in the breadcrumbs
+      expect(element('#pageHeader-breadcrumb2').count()).toBe(1);
+      element('#pageHeader-breadcrumb2').click();
 
       // should be on the feed election page
-      expect(element('#feed-election-content').count()).toBe(1);
 
       // should have a state link
       expect(element('#state-id a').count()).toBe(1);

--- a/services/mappers/feed.js
+++ b/services/mappers/feed.js
@@ -101,6 +101,7 @@ var mapOverview = function(path, feed) {
     election: _path.join(path, '/election'),
     state: _path.join(path, '/election/state'),
     county_map: county,
+    overview: _path.join(path, '/'),
     localities: _path.join(path, '/election/state/localities'),
     polling_locations: _path.join(path, '/polling'),
     election_contests: _path.join(path, '/election/contests'),


### PR DESCRIPTION
This PR consists of a number of front-end changes for Metis and addresses the following cards:

<a href="https://www.pivotaltracker.com/n/projects/1106394/stories/95478038">Remove "Election" from Navigation</a>
<a href="https://www.pivotaltracker.com/n/projects/1106394/stories/95477960">Add "Overview" Tab to Navigation</a>
<a href="https://www.pivotaltracker.com/n/projects/1106394/stories/94958690">Remove fields from candidate tables</a>
<a href="https://www.pivotaltracker.com/n/projects/1106394/stories/95477478">Rename Source Page "Source & Election"</a>
<a href="https://www.pivotaltracker.com/n/projects/1106394/stories/95478306">Add Error Count to the table on State Page</a>
<a href="https://www.pivotaltracker.com/n/projects/1106394/stories/94869696">Breadcrumbs throughout Metis should not include the 'Feeds' link</a>

It also addresses the following chores:
<a href="https://www.pivotaltracker.com/n/projects/1106394/stories/96025424">Retitle Contest Page</a>
<a href="https://www.pivotaltracker.com/n/projects/1106394/stories/96024066">Reorder Navigation Tabs</a>
<a href="https://www.pivotaltracker.com/n/projects/1106394/stories/96024156">Remove Free Floating Error Count Bubble from State Page</a>
<a href="https://www.pivotaltracker.com/n/projects/1106394/stories/96025198">Change Page Title from "State" to "Polling Locations"</a>

Test cases are still to be updated and will be part of a separate PR.

