### PR TITLE
Refactor /db/ routes

### DIFF
--- a/pg/gets.js
+++ b/pg/gets.js
@@ -30,18 +30,18 @@ var simpleQueryResponder = function(sqlQuery, paramsFn) {
 module.exports = {
   // Functions below return arrays for the various queries with the requirement of an ID.
   getFeeds: simpleQueryResponder("SELECT r.public_id, date(r.start_time) AS date, CASE WHEN r.end_time IS NOT NULL THEN r.end_time - r.start_time END AS duration, r.complete, s.name AS state, e.election_type, e.date FROM results r LEFT JOIN states s ON s.results_id = r.id LEFT JOIN elections e ON e.results_id = r.id ORDER BY r.start_time DESC;"),
-  getResults: simpleQueryResponder("SELECT * FROM results WHERE public_id=$1", function(req) { return [decodeURIComponent(req.query.id)]; }),
-  getFeedContest: simpleQueryResponder("SELECT c.*, (SELECT COUNT(v.*) FROM validations v WHERE r.id = v.result_id AND v.scope = 'contests') AS error_count FROM contests c INNER JOIN results r ON r.id = c.results_id WHERE r.public_id=$1 AND c.id=$2;", function(req) { return [decodeURIComponent(req.params.feedid), decodeURIComponent(req.params.contestid)]; }),
+  getResults: simpleQueryResponder("SELECT * FROM results WHERE public_id=$1", function(req) { return [decodeURIComponent(req.params.feedid)]; }),
+  getFeedContest: simpleQueryResponder("SELECT c.*, (SELECT COUNT(v.*) FROM validations v WHERE r.id = v.results_id AND v.scope = 'contests') AS error_count FROM contests c INNER JOIN results r ON r.id = c.results_id WHERE r.public_id=$1 AND c.id=$2;", function(req) { return [decodeURIComponent(req.params.feedid), decodeURIComponent(req.params.contestid)]; }),
   getFeedContestBallot: simpleQueryResponder("SELECT c.ballot_id, (SELECT COUNT(b.referendum_id) FROM ballots b WHERE b.id=c.ballot_id AND b.results_id = c.results_id) AS referendum_count, (SELECT COUNT(*) FROM ballot_candidates bc WHERE bc.results_id=c.results_id AND ballot_id=c.ballot_id) AS candidate_count FROM contests c INNER JOIN results r ON r.id=c.results_id WHERE r.public_id=$1 AND c.id=$2;", function(req) { return [decodeURIComponent(req.params.feedid), decodeURIComponent(req.params.contestid)]; }),
   getFeedContestElectoralDistrict: simpleQueryResponder("SELECT c.electoral_district_id, e.name, (SELECT COUNT(*) FROM precinct_electoral_districts ped WHERE ped.electoral_district_id = c.electoral_district_id) AS precinct_count, (SELECT COUNT(*) FROM precinct_split_electoral_districts psed WHERE psed.electoral_district_id = c.electoral_district_id) AS precinct_split_count FROM contests c INNER JOIN electoral_districts e ON c.electoral_district_id = e.id INNER JOIN results r ON r.id = c.results_id WHERE r.public_id=$1 AND c.id=$2;", function(req) { return [decodeURIComponent(req.params.feedid), decodeURIComponent(req.params.contestid)]; }),
   getFeedContestResult: simpleQueryResponder("SELECT cr.id, cr.total_votes, cr.total_valid_votes, cr.overvotes, cr.blank_votes, cr.certification FROM contests c INNER JOIN contest_results cr ON cr.contest_id = c.id INNER JOIN results r ON r.id = c.results_id WHERE r.public_id=$1 AND c.id=$2;", function(req) { return [decodeURIComponent(req.params.feedid), decodeURIComponent(req.params.contestid)]; }),
   getFeedContestBallotLineResults: simpleQueryResponder("SELECT blr.id, blr.votes, blr.certification FROM contests c INNER JOIN ballot_line_results blr ON blr.contest_id = c.id INNER JOIN results r ON r.id = c.results_id WHERE r.public_id=$1 AND c.id=$2;", function(req) { return [decodeURIComponent(req.params.feedid), decodeURIComponent(req.params.contestid)]; }),
   getFeedContests: simpleQueryResponder("SELECT c.* FROM contests c INNER JOIN results r ON r.id = c.results_id WHERE r.public_id=$1", function(req) { return [decodeURIComponent(req.params.feedid)]; }),
   getFeedLocalities: simpleQueryResponder("SELECT l.id, l.name, COUNT(p.*) AS precincts, CONCAT('#/feeds/', l.results_id, '/election/state/localities/', l.id) as link FROM localities l INNER JOIN precincts p ON p.locality_id = l.id AND p.results_id = l.results_id INNER JOIN results r ON l.results_id = r.id WHERE r.public_id = $1 GROUP BY l.id, l.name, l.results_id ORDER BY l.id;", function(req) { return [decodeURIComponent(req.params.feedid)]; }),
-  getFeedState: simpleQueryResponder("SELECT s.id, s.name, (SELECT COUNT(l.*) FROM localities l WHERE l.results_id = s.results_id) AS locality_count, (SELECT COUNT(v.*) FROM validations v WHERE v.result_id = s.results_id AND v.scope = 'states') AS error_count FROM states s INNER JOIN results r ON s.results_id = r.id WHERE r.public_id = $1 GROUP BY s.id, s.name, s.results_id ORDER BY s.id;", function(req) { return [decodeURIComponent(req.params.feedid)]; }),
+  getFeedState: simpleQueryResponder("SELECT s.id, s.name, (SELECT COUNT(l.*) FROM localities l WHERE l.results_id = s.results_id) AS locality_count, (SELECT COUNT(v.*) FROM validations v WHERE v.results_id = s.results_id AND v.scope = 'states') AS error_count FROM states s INNER JOIN results r ON s.results_id = r.id WHERE r.public_id = $1 GROUP BY s.id, s.name, s.results_id ORDER BY s.id;", function(req) { return [decodeURIComponent(req.params.feedid)]; }),
   getFeedElectionAdministrations: simpleQueryResponder("SELECT e.id, e.name, CONCAT(e.physical_address_city, ', ', e.physical_address_state, ', ', e.physical_address_zip) AS address, CONCAT('#/feeds/', e.results_id, '/election/state/electionadministration') AS link FROM election_administrations e INNER JOIN results r ON e.results_id = r.id WHERE r.public_id=$1;", function(req) { return [decodeURIComponent(req.params.feedid)]; }),
-  getFeedElection: simpleQueryResponder("SELECT e.*, (SELECT COUNT(v.*) FROM validations v WHERE v.result_id = e.results_id AND scope='elections') AS error_count FROM elections e INNER JOIN results r ON r.id = e.results_id WHERE r.public_id=$1", function(req) { return [decodeURIComponent(req.params.feedid)]; }),
-  getFeedSource: simpleQueryResponder("SELECT s.*, (SELECT COUNT(v.*) FROM validations v WHERE v.result_id = s.results_id AND scope='sources') AS error_count FROM sources s INNER JOIN results r ON r.id = s.results_id WHERE r.public_id=$1", function(req) { return [decodeURIComponent(req.params.feedid)]; }),
+  getFeedElection: simpleQueryResponder("SELECT e.*, (SELECT COUNT(v.*) FROM validations v WHERE v.results_id = e.results_id AND scope='elections') AS error_count FROM elections e INNER JOIN results r ON r.id = e.results_id WHERE r.public_id=$1", function(req) { return [decodeURIComponent(req.params.feedid)]; }),
+  getFeedSource: simpleQueryResponder("SELECT s.*, (SELECT COUNT(v.*) FROM validations v WHERE v.results_id = s.results_id AND scope='sources') AS error_count FROM sources s INNER JOIN results r ON r.id = s.results_id WHERE r.public_id=$1", function(req) { return [decodeURIComponent(req.params.feedid)]; }),
   getFeedOverview: function(req, res) {
     var client = conn.openPostgres();
     var feedid = req.params.feedid;
@@ -92,45 +92,14 @@ module.exports = {
 
     conn.closePostgres(query, client, res);
   },
-  getValidations: function(req, res) {
-    var client = conn.openPostgres();
-    var query = client.query("SELECT v.* FROM validations v INNER JOIN results r ON v.result_id = r.id WHERE r.public_id=$1", [decodeURIComponent(req.query.id)]);
-
-    query.on("row", function (row, result) {
-      result.addRow(row);
-    });
-
-    query.on("end", function (result) {
-      var edn = require("jsedn");
-
-      for (i = 0; i < result.rows.length; i++) {
-        var parsed_message = edn.toJS(edn.parse(result.rows[i]["message"]));
-        result.rows[i]["message"] = parsed_message;
-      }
-
-      client.end();
-      resp.writeResponse(result.rows, res)
-    });
-  },
   getValidationsErrorCount: function(req, res) {
     var client = conn.openPostgres();
-    var query = client.query("SELECT message FROM validations v INNER JOIN results r ON v.result_id = r.id WHERE r.public_id=$1", [decodeURIComponent(req.query.id)]);
+    var query = client.query("SELECT COUNT(*) AS errorcount FROM validations v INNER JOIN results r ON r.id = v.results_id WHERE r.public_id = $1", [decodeURIComponent(req.params.feedid)]);
 
     query.on("row", function (row, result) {
       result.addRow(row);
     });
 
-    query.on("end", function (result) {
-      var edn = require("jsedn");
-      var count = 0;
-
-      for (i = 0; i < result.rows.length; i++) {
-        var parsed_message = edn.toJS(edn.parse(result.rows[i]["message"]));
-        count += parsed_message.length || 1;
-      }
-
-      client.end();
-      resp.writeResponse(count, res)
-    });
+    conn.closePostgres(query, client, res);
   }
 }

--- a/pg/gets.js
+++ b/pg/gets.js
@@ -92,14 +92,5 @@ module.exports = {
 
     conn.closePostgres(query, client, res);
   },
-  getValidationsErrorCount: function(req, res) {
-    var client = conn.openPostgres();
-    var query = client.query("SELECT COUNT(*) AS errorcount FROM validations v INNER JOIN results r ON r.id = v.results_id WHERE r.public_id = $1", [decodeURIComponent(req.params.feedid)]);
-
-    query.on("row", function (row, result) {
-      result.addRow(row);
-    });
-
-    conn.closePostgres(query, client, res);
-  }
+  getValidationsErrorCount: simpleQueryResponder("SELECT COUNT(*) AS errorcount FROM validations v INNER JOIN results r ON r.id = v.results_id WHERE r.public_id = $1", function(req) { return [decodeURIComponent(req.params.feedid)]; })
 }

--- a/pg/services.js
+++ b/pg/services.js
@@ -1,23 +1,22 @@
 var pg = require("./gets.js");
 
 function registerPostgresServices (app) {
-  app.get('/db/results', function(req,res){ pg.getResults(req,res); });
-  app.get('/db/validations', function(req,res){ pg.getValidations(req,res); });
-  app.get('/db/validations/errorCount', function(req,res){ pg.getValidationsErrorCount(req,res); });
   app.get('/db/feeds', pg.getFeeds);
-  app.get('/db/feeds/:feedid/contests/:contestid', function(req,res){ pg.getFeedContest(req,res); });
-  app.get('/db/feeds/:feedid/contests/:contestid/ballot', function(req,res){ pg.getFeedContestBallot(req,res); });
-  app.get('/db/feeds/:feedid/contests/:contestid/electoral-district', function(req,res){ pg.getFeedContestElectoralDistrict(req,res); });
-  app.get('/db/feeds/:feedid/contests/:contestid/result', function(req,res){ pg.getFeedContestResult(req,res); });
-  app.get('/db/feeds/:feedid/contests/:contestid/ballot-line-results', function(req,res){ pg.getFeedContestBallotLineResults(req,res); });
-  app.get('/db/feeds/:feedid/contests', function(req,res){ pg.getFeedContests(req,res); });
+  app.get('/db/feeds/:feedid/contests', pg.getFeedContests);
+  app.get('/db/feeds/:feedid/contests/:contestid', pg.getFeedContest);
+  app.get('/db/feeds/:feedid/contests/:contestid/ballot', pg.getFeedContestBallot);
+  app.get('/db/feeds/:feedid/contests/:contestid/ballot-line-results', pg.getFeedContestBallotLineResults);
+  app.get('/db/feeds/:feedid/contests/:contestid/electoral-district', pg.getFeedContestElectoralDistrict);
+  app.get('/db/feeds/:feedid/contests/:contestid/result', pg.getFeedContestResult);
   app.get('/db/feeds/:feedid/contests/overview', pg.getFeedContestsOverview);
-  app.get('/db/feeds/:feedid/overview', pg.getFeedOverview);
-  app.get('/db/feeds/:feedid/localities', pg.getFeedLocalities);
+  app.get('/db/feeds/:feedid/election', pg.getFeedElection);
   app.get('/db/feeds/:feedid/election/state', pg.getFeedState);
   app.get('/db/feeds/:feedid/election/state/election-administrations', pg.getFeedElectionAdministrations);
-  app.get('/db/feeds/:feedid/election', pg.getFeedElection);
+  app.get('/db/feeds/:feedid/localities', pg.getFeedLocalities);
+  app.get('/db/feeds/:feedid/overview', pg.getFeedOverview);
+  app.get('/db/feeds/:feedid/results', pg.getResults);
   app.get('/db/feeds/:feedid/source', pg.getFeedSource);
+  app.get('/db/feeds/:feedid/validations/errorCount', pg.getValidationsErrorCount);
 }
 
 exports.registerPostgresServices = registerPostgresServices;

--- a/public/assets/js/app/controllers/feedOverviewController.js
+++ b/public/assets/js/app/controllers/feedOverviewController.js
@@ -13,7 +13,8 @@ function FeedOverviewCtrl($scope, $rootScope, $feedDataPaths, $feedsService, $ro
   $feedDataPaths.getResponse({ path: errorPath,
                                scope: $rootScope,
                                key: "errorCount",
-                               errorMessage: "Could not retrieve Feed Error Count."});
+                               errorMessage: "Could not retrieve Feed Error Count."},
+                             function(result) { $rootScope.errorCount = result[0].errorcount; });
   $feedDataPaths.getResponse({ path: '/db/feeds/' + feedid + '/overview',
                                scope:  $rootScope,
                                key: 'overviewData',

--- a/public/assets/js/app/services/paths.js
+++ b/public/assets/js/app/services/paths.js
@@ -2,9 +2,8 @@
 
 vipApp.factory('$feedDataPaths', function ($http) {
   return {
-    getFeedResultsPath: function (feedid) { return '/db/results?id=' + feedid },
-    getFeedValidationsPath: function (feedid) { return '/db/validations?id=' + feedid },
-    getFeedValidationsErrorCountPath: function (feedid) { return '/db/validations/errorCount?id=' + feedid },
+    getFeedResultsPath: function (feedid) { return '/db/feeds/' + feedid + '/results' },
+    getFeedValidationsErrorCountPath: function (feedid) { return '/db/feeds/' + feedid + '/validations/errorCount' },
     getFeedContestsPath: function (feedid) { return "/db/feeds/" + feedid + "/contests" },
     getContestsOverviewTablePath: function(feedid) { return "/db/feeds/" + feedid + "/contests/overview" },
     getResponse: function(options, callback) {


### PR DESCRIPTION
* Remove unused `getValidations`
* Use `feedid` url param consistently
* Update queries to use `results_id` now that that's standardized in data-processor
* Update `getValidationsErrorCount` to be a simple count on the validations table
* Sort routes in pg/services.js for niceness

Pivotal story: [97023298](https://www.pivotaltracker.com/story/show/97023298)