### PR TITLE
[WR] show street segment errors for a specific locality

### DIFF
--- a/pg/gets_errors.js
+++ b/pg/gets_errors.js
@@ -11,5 +11,6 @@ module.exports = {
   getFeedCandidateErrors: errorResponder(queries.candidateErrors, ['candidateid']),
   getFeedContestBallotErrors: errorResponder(queries.contestBallotErrors, ['contestid']),
   getFeedContestErrors: errorResponder(queries.contestErrors, ['contestid']),
+  getFeedLocalityStreetSegmentsErrors: errorResponder(queries.localityStreetSegmentsErrors, ['localityid']),
   getFeedErrors: errorResponder(queries.errors),
 }

--- a/pg/queries.js
+++ b/pg/queries.js
@@ -499,5 +499,9 @@ module.exports = {
                                        "v.scope = 'ballots' AND c.id = $2"),
   contestErrors: buildErrorQuery("INNER JOIN contests c ON v.identifier = c.id AND c.results_id = v.results_id",
                                  "v.scope = 'contests' AND c.id = $2"),
+  localityStreetSegmentsErrors: buildErrorQuery("INNER JOIN localities l ON l.results_id = v.results_id \
+                                                 INNER JOIN precincts p ON p.locality_id = l.id AND p.results_id = v.results_id \
+                                                 INNER JOIN street_segments ss ON ss.precinct_id = p.id AND ss.id = v.identifier AND ss.results_id = v.results_id",
+                                                 "v.scope = 'street-segments' AND l.id = $2"),
   errors: buildErrorQuery("", "")
 }

--- a/pg/services.js
+++ b/pg/services.js
@@ -81,6 +81,7 @@ function registerPostgresServices (app) {
   app.get('/db/feeds/:feedid/election/contests/:contestid/ballot/candidates/:candidateid/errors', pgErrors.getFeedCandidateErrors);
   app.get('/db/feeds/:feedid/election/contests/:contestid/ballot/errors', pgErrors.getFeedContestBallotErrors);
   app.get('/db/feeds/:feedid/election/contests/:contestid/errors', pgErrors.getFeedContestErrors);
+  app.get('/db/feeds/:feedid/election/state/localities/:localityid/overview/streetsegments/errors', pgErrors.getFeedLocalityStreetSegmentsErrors);
   app.get('/db/feeds/:feedid/election/errors', pgErrors.overviewErrors("elections"));
   app.get('/db/feeds/:feedid/errors', pgErrors.getFeedErrors);
   app.get('/db/feeds/:feedid/overview/ballots/errors', pgErrors.overviewErrors("ballots"));


### PR DESCRIPTION
[Pivotal Card](https://www.pivotaltracker.com/story/show/99182400)

Fixes a bug where street segment errors for a specific locality were not showing.

@tie-rack, is this inline with the way you set these up?