### PR TITLE
Add error count to every page

### DIFF
--- a/pg/gets.js
+++ b/pg/gets.js
@@ -14,6 +14,7 @@ module.exports = {
   // Functions below return arrays for the various queries with the requirement of an ID.
   getFeeds: util.simpleQueryResponder(queries.feeds),
   getResults: util.simpleQueryResponder(queries.results, util.paramExtractor()),
+  getErrorsTotal: util.simpleQueryResponder(queries.errorsTotal, util.paramExtractor()),
   
   // Feed Contest-related queries
   getFeedContest: util.simpleQueryResponder(queries.contest, util.paramExtractor(['contestid'])),

--- a/pg/queries.js
+++ b/pg/queries.js
@@ -33,6 +33,10 @@ module.exports = {
           LEFT JOIN elections e ON e.results_id = r.id \
           ORDER BY r.start_time DESC;",
   results: "SELECT * FROM results WHERE public_id=$1",
+  errorsTotal: "SELECT COUNT(v.*)::int \
+                FROM validations v \
+                INNER JOIN results r ON r.id = v.results_id \
+                WHERE r.public_id = $1",
   contest: "SELECT c.*, \
                    (SELECT COUNT(v.*) \
                     FROM validations v \

--- a/pg/services.js
+++ b/pg/services.js
@@ -4,6 +4,7 @@ var csv = require('./csv.js');
 
 function registerPostgresServices (app) {
   app.get('/db/feeds', pg.getFeeds);
+  app.get('/db/feeds/:feedid/error-total-count', pg.getErrorsTotal);
   app.get('/db/feeds/:feedid/election', pg.getFeedElection);
   app.get('/db/feeds/:feedid/election/state', pg.getFeedState);
   app.get('/db/feeds/:feedid/election/state/election-administration', pg.getFeedStateElectionAdministration);

--- a/public/assets/js/app/controllers/asideController.js
+++ b/public/assets/js/app/controllers/asideController.js
@@ -1,0 +1,9 @@
+function AsideCtrl($scope, $rootScope, $feedDataPaths, $routeParams) {
+  var feedid = $routeParams.vipfeed;
+
+  $feedDataPaths.getResponse({ path: '/db/feeds/' + feedid + '/error-total-count',
+                               scope: $rootScope,
+                               key: "errorCount",
+                               errorMessage: "Could not retrieve Feed Error Count."},
+                             function(result) { $rootScope.errorCount = result[0].count; });
+}

--- a/public/assets/js/app/controllers/feedContestController.js
+++ b/public/assets/js/app/controllers/feedContestController.js
@@ -3,16 +3,9 @@
  */
 
 function FeedContestCtrl($scope, $rootScope, $feedDataPaths, $feedsService, $routeParams, $appProperties, $location, $filter, ngTableParams) {
-
   // get the vipfeed param from the route
   var feedid = $scope.vipfeed = $routeParams.vipfeed;  
   var contestid = $routeParams.contest;
-
-  var errorPath = $feedDataPaths.getFeedValidationsErrorCountPath(feedid);
-  $feedDataPaths.getResponse({ path: errorPath,
-                               scope: $rootScope,
-                               key: "errorCount",
-                               errorMessage: "Could not retrieve Feed Error Count."});
   
   $feedDataPaths.getResponse({ path: '/db/feeds/' + feedid + '/contests/' + contestid,
                                scope:  $rootScope,

--- a/public/assets/js/app/controllers/feedContestsController.js
+++ b/public/assets/js/app/controllers/feedContestsController.js
@@ -5,12 +5,6 @@
 
 function FeedContestsCtrl($scope, $rootScope, $feedDataPaths, $feedsService, $routeParams, $appProperties, $location, $filter, ngTableParams) {
   var feedid = $scope.vipfeed = $routeParams.vipfeed;
-
-  var errorPath = $feedDataPaths.getFeedValidationsErrorCountPath(feedid);
-  $feedDataPaths.getResponse({ path: errorPath,
-                               scope: $rootScope,
-                               key: "errorCount",
-                               errorMessage: "Could not retrieve Feed Error Count."});
   
   $feedDataPaths.getResponse({ path: '/db/feeds/' + feedid + '/contests',
                                scope: $rootScope,

--- a/public/assets/js/app/controllers/feedOverviewController.js
+++ b/public/assets/js/app/controllers/feedOverviewController.js
@@ -5,13 +5,6 @@
  */
 function FeedOverviewCtrl($scope, $rootScope, $feedDataPaths, $routeParams, $location, $appProperties, $filter, ngTableParams) {
   var feedid = $scope.vipfeed = $routeParams.vipfeed;
-
-  var errorPath = $feedDataPaths.getFeedValidationsErrorCountPath(feedid);
-  $feedDataPaths.getResponse({ path: errorPath,
-                               scope: $rootScope,
-                               key: "errorCount",
-                               errorMessage: "Could not retrieve Feed Error Count."},
-                             function(result) { $rootScope.errorCount = result[0].errorcount; });
   
   $feedDataPaths.getResponse({ path: '/db/feeds/' + feedid + '/overview',
                                scope:  $rootScope,

--- a/public/assets/js/app/controllers/feedStateController.js
+++ b/public/assets/js/app/controllers/feedStateController.js
@@ -4,16 +4,8 @@
  *
  */
 function FeedStateCtrl($scope, $rootScope, $feedDataPaths, $feedsService, $routeParams, $appProperties, $location, $filter, ngTableParams) {
-
   // get the vipfeed param from the route
-  var feedid = $routeParams.vipfeed;
-  $scope.vipfeed = feedid;
-
-  var errorPath = $feedDataPaths.getFeedValidationsErrorCountPath(feedid);
-  $feedDataPaths.getResponse({ path: errorPath,
-                               scope: $rootScope,
-                               key: "errorCount",
-                               errorMessage: "Could not retrieve Feed Error Count."});
+  var feedid = $scope.vipfeed = $routeParams.vipfeed;
   
   $feedDataPaths.getResponse({ path: '/db/feeds/' + feedid + '/election/state',
                                scope: $rootScope,

--- a/public/assets/js/app/services/paths.js
+++ b/public/assets/js/app/services/paths.js
@@ -2,10 +2,7 @@
 
 vipApp.factory('$feedDataPaths', function ($http) {
   return {
-    getFeedResultsPath: function (feedid) { return '/db/feeds/' + feedid + '/results' },
     getFeedValidationsErrorCountPath: function (feedid) { return '/db/feeds/' + feedid + '/validations/errorCount' },
-    getFeedContestsPath: function (feedid) { return "/db/feeds/" + feedid + "/contests" },
-    getContestsOverviewTablePath: function(feedid) { return "/db/feeds/" + feedid + "/contests/overview" },
     getResponse: function(options, callback) {
       $http.get(options['path']).
         success(function (results, status) {

--- a/public/assets/js/app/services/paths.js
+++ b/public/assets/js/app/services/paths.js
@@ -2,7 +2,6 @@
 
 vipApp.factory('$feedDataPaths', function ($http) {
   return {
-    getFeedValidationsErrorCountPath: function (feedid) { return '/db/feeds/' + feedid + '/validations/errorCount' },
     getResponse: function(options, callback) {
       $http.get(options['path']).
         success(function (results, status) {

--- a/public/index.html
+++ b/public/index.html
@@ -58,6 +58,9 @@
   <!-- Directives -->
   <script src="assets/js/app/directives/directives.js"></script>
 
+  <!-- Aside -->
+  <script src="assets/js/app/controllers/asideController.js"></script>
+
   <!-- Home -->
   <script src="assets/js/app/controllers/homeController.js"></script>
   <script src="assets/js/app/services/homeService.js"></script>
@@ -155,7 +158,7 @@
         </footer><!-- / contentinfo -->
       </div><!-- /.content -->
 
-      <aside class="feed-meta" ng-if="$location.url()!='/feeds' && pageHeader.section==='feeds'&& pageHeader.title!=='Feeds'" ng-include src="'app/partials/aside.html'"></aside>
+      <aside class="feed-meta" ng-if="$location.url()!='/feeds' && pageHeader.section==='feeds' && pageHeader.title!=='Feeds'" ng-controller="AsideCtrl" ng-include src="'app/partials/aside.html'"></aside>
 
     </div><!-- / .wrapper -->
 


### PR DESCRIPTION
[Pivotal Card](https://www.pivotaltracker.com/story/show/98680462)

Instead of attempting a new call inside of each controller, a new aside controller nested inside the main view handles querying for the total number of errors. Also did a bit of updating to `paths.js` to more adequately reflect the reality of the code base now.