### PR TITLE
Only one email per processing complete message

### DIFF
--- a/notifications/queue.js
+++ b/notifications/queue.js
@@ -28,7 +28,7 @@ var onChannelOpen = function(err, ch) {
   var processingComplete = config.notifications.topics.processingComplete;
 
   ch.assertExchange(ex, "topic", exOptions);
-  ch.assertQueue('metisProcessingCompleteEmail', {}, function(err, ok) {
+  ch.assertQueue('dashboard.notifications.feed_processed', {}, function(err, ok) {
     logAndThrowPossibleError(err);
 
     var queue = ok.queue;

--- a/notifications/queue.js
+++ b/notifications/queue.js
@@ -28,7 +28,7 @@ var onChannelOpen = function(err, ch) {
   var processingComplete = config.notifications.topics.processingComplete;
 
   ch.assertExchange(ex, "topic", exOptions);
-  ch.assertQueue('', {exclusive: true}, function(err, ok) {
+  ch.assertQueue('metisProcessingCompleteEmail', {}, function(err, ok) {
     logAndThrowPossibleError(err);
 
     var queue = ok.queue;

--- a/notifications/queue.js
+++ b/notifications/queue.js
@@ -34,7 +34,8 @@ var onChannelOpen = function(err, ch) {
     var queue = ok.queue;
     ch.bindQueue(queue, ex, processingComplete, {}, logAndThrowPossibleError);
 
-    ch.consume(queue, processMessage, {}, logAndThrowPossibleError);
+    // TODO: Remove `noAck: true` option and only ack messages successfully handled
+    ch.consume(queue, processMessage, {noAck: true}, logAndThrowPossibleError);
   });
 };
 


### PR DESCRIPTION
Share a queue bound to the "processing.complete" topic among all instances so that only one instance takes the message and sends emails about it. Otherwise, we send as many copies of the email as there are instances!

[Pivotal story](https://www.pivotaltracker.com/story/show/102519538)