### PR TITLE
[WR] add filter to properly add commas for addresses

### DIFF
--- a/public/app/partials/feed-candidate.html
+++ b/public/app/partials/feed-candidate.html
@@ -18,8 +18,8 @@
     <dt class="key">Photo Url:</dt> <dd id="candidate-photourl" class="value">{{feedCandidate.photo_url}}</dd>
     <dt class="key">Filed Mailing Address:</dt>
     <dd id="physical_address" class="value">
-    {{feedCandidate.filed_mailing_address_line1}}<span ng-if="feedCandidate.filed_mailing_address_line1">,</span>
-    {{feedCandidate.filed_mailing_address_city}}<span ng-if="feedCandidate.filed_mailing_address_city">,</span>
+    {{feedCandidate.filed_mailing_address_line1 | addComma}}
+    {{feedCandidate.filed_mailing_address_city | addComma}}
     {{feedCandidate.filed_mailing_address_state}} {{feedCandidate.filed_mailing_address_zip}}</dd>
 
     <dt class="key">Email:</dt> <dd id="candidate-email" class="value">{{feedCandidate.email}}</dd>

--- a/public/app/partials/feed-earlyvotesite.html
+++ b/public/app/partials/feed-earlyvotesite.html
@@ -8,8 +8,8 @@
     <dd id="name" class="value">{{feedEarlyVoteSite.name}}</dd>
     <dt class="key">Address:</dt>
     <dd id="address" class="value">
-      {{feedEarlyVoteSite.address_line1}},
-      {{feedEarlyVoteSite.address_city}},
+      {{feedEarlyVoteSite.address_line1 | addComma}}
+      {{feedEarlyVoteSite.address_city | addComma}}
       {{feedEarlyVoteSite.address_state}} {{feedEarlyVoteSite.address.zip}}</dd>
     </dd>
     <dt class="key">Directions:</dt>

--- a/public/app/partials/feed-earlyvotesites.html
+++ b/public/app/partials/feed-earlyvotesites.html
@@ -9,7 +9,7 @@
       </td>
       <td id="earlyVoteSite-name{{$index}}" data-title="'Name'" sortable="'name'"><a href="{{$location.absUrl()}}/{{earlyVoteSite.id}}" data-title-text="Name"><span class="td-text">{{earlyVoteSite.name}}</span></a>
       </td>
-      <td id="earlyVoteSite-address{{$index}}" data-title="'Address'" sortable="'city'"><a href="{{$location.absUrl()}}/{{earlyVoteSite.id}}" data-title-text="Address"><span class="td-text">{{earlyVoteSite.address_city}}, {{earlyVoteSite.address_state}} {{earlyVoteSite.address_zip}}</span></a>
+      <td id="earlyVoteSite-address{{$index}}" data-title="'Address'" sortable="'city'"><a href="{{$location.absUrl()}}/{{earlyVoteSite.id}}" data-title-text="Address"><span class="td-text">{{earlyVoteSite.address_city | addComma}} {{earlyVoteSite.address_state}} {{earlyVoteSite.address_zip}}</span></a>
       </td>
     </tr>
   </table>

--- a/public/app/partials/feed-electionadministration.html
+++ b/public/app/partials/feed-electionadministration.html
@@ -10,13 +10,13 @@
     <dd id="name" class="value">{{feedElectionAdministration.name || feedElectionAdministration.physical_address_location_name}}</dd>
     <dt class="key">Physical Address:</dt>
     <dd id="physical_address" class="value">
-      {{feedElectionAdministration.physical_address_line1}},
-      {{feedElectionAdministration.physical_address_city}},
+      {{feedElectionAdministration.physical_address_line1 | addComma}}
+      {{feedElectionAdministration.physical_address_city | addComma}}
       {{feedElectionAdministration.physical_address_state}} {{feedElectionAdministration.physical_address_zip}}</dd>
     <dt class="key">Mailing Address:</dt>
     <dd id="mailing_address" class="value">
-      {{feedElectionAdministration.mailing_address_line1}},
-      {{feedElectionAdministration.mailing_address_city}},
+      {{feedElectionAdministration.mailing_address_line1 | addComma}}
+      {{feedElectionAdministration.mailing_address_city | addComma}}
       {{feedElectionAdministration.mailing_address_state}} {{feedElectionAdministration.mailing_address_zip}}</dd>
     </dd>
     <dt class="key">Elections URL:</dt>

--- a/public/app/partials/feed-locality.html
+++ b/public/app/partials/feed-locality.html
@@ -49,7 +49,7 @@
     <tr id="earlyVoteSite{{$index}}" ng-repeat="earlyVoteSite in $data">
       <td id="earlyVoteSite-id{{$index}}" data-title="'ID'" sortable="'id'"><a href="#/feeds/{{vipfeed}}/election/state/earlyvotesites/{{earlyVoteSite.id}}" data-title-text="ID"><span class="td-text">{{earlyVoteSite.id}}</span></a></td>
       <td id="earlyVoteSite-name{{$index}}" data-title="'Name'" sortable="'name'"><a href="#/feeds/{{vipfeed}}/election/state/earlyvotesites/{{earlyVoteSite.id}}" data-title-text="Name"><span class="td-text">{{earlyVoteSite.name}}</span></a></td>
-      <td id="earlyVoteSite-address{{$index}}" data-title="'Address'" sortable="'address_city'"><a href="#/feeds/{{vipfeed}}/election/state/earlyvotesites/{{earlyVoteSite.id}}" data-title-text="Address"><span class="td-text">{{earlyVoteSite.address_city}}, {{earlyVoteSite.address_state}} {{earlyVoteSite.address_zip}}</span></a></td>
+      <td id="earlyVoteSite-address{{$index}}" data-title="'Address'" sortable="'address_city'"><a href="#/feeds/{{vipfeed}}/election/state/earlyvotesites/{{earlyVoteSite.id}}" data-title-text="Address"><span class="td-text">{{earlyVoteSite.address_city | addComma}} {{earlyVoteSite.address_state}} {{earlyVoteSite.address_zip}}</span></a></td>
     </tr>
   </table>
 
@@ -79,7 +79,7 @@
     <tr>
       <td id="locality-administration-id" class="id"><a href="{{$location.absUrl()}}/electionadministration" data-title-text="ID"><span class="td-text">{{feedElectionAdministration.id}}</span></a></td>
       <td id="locality-administration-name" class="name"><a href="{{$location.absUrl()}}/electionadministration" data-title-text="name"><span class="td-text">{{feedElectionAdministration.name}}</span></a></td>
-      <td id="locality-administration-address" class="address"><a href="{{$location.absUrl()}}/electionadministration" data-title-text="address"><span class="td-text">{{feedElectionAdministration.physical_address_city}}, {{feedElectionAdministration.physical_address_state}} {{feedElectionAdministration.physical_address_zip}}</span></a></td>
+      <td id="locality-administration-address" class="address"><a href="{{$location.absUrl()}}/electionadministration" data-title-text="address"><span class="td-text">{{feedElectionAdministration.physical_address_city | addComma}} {{feedElectionAdministration.physical_address_state}} {{feedElectionAdministration.physical_address_zip}}</span></a></td>
     </tr>
     </tbody>
   </table>

--- a/public/app/partials/feed-pollinglocation.html
+++ b/public/app/partials/feed-pollinglocation.html
@@ -8,8 +8,8 @@
     <dd id="name" class="value">{{feedPollingLocation.address_location_name}}</dd>
     <dt class="key">Address:</dt>
     <dd id="address" class="value">
-      {{feedPollingLocation.address_line1}},
-      {{feedPollingLocation.address_city}},
+      {{feedPollingLocation.address_line1 | addComma}}
+      {{feedPollingLocation.address_city | addComma}}
       {{feedPollingLocation.address_state}} {{feedPollingLocation.address_zip}}</dd>
     </dd>
     <dt class="key">Directions:</dt>

--- a/public/app/partials/feed-pollinglocations.html
+++ b/public/app/partials/feed-pollinglocations.html
@@ -6,7 +6,7 @@
     <tr id="pollingLocation{{$index}}" ng-repeat="pollingLocation in $data">
       <td id="pollingLocation-id{{$index}}" data-title="'ID'" sortable="'id'"><a href="{{$location.absUrl()}}/{{pollingLocation.id}}" data-title-text="ID"><span class="td-text">{{pollingLocation.id}}</span></a></td>
       <td id="pollingLocation-name{{$index}}" data-title="'Name'" sortable="'name'"><a href="{{$location.absUrl()}}/{{pollingLocation.id}}" data-title-text="Name"><span class="td-text">{{pollingLocation.address_location_name}}</span></a></td>
-      <td id="pollingLocation-address{{$index}}" data-title="'Address'" sortable="'address'"><a href="{{$location.absUrl()}}/{{pollingLocation.id}}" data-title-text="Address"><span class="td-text">{{pollingLocation.address_city}}, {{pollingLocation.address_state}} {{pollingLocation.address_zip}}</span></a></td>
+      <td id="pollingLocation-address{{$index}}" data-title="'Address'" sortable="'address'"><a href="{{$location.absUrl()}}/{{pollingLocation.id}}" data-title-text="Address"><span class="td-text">{{pollingLocation.address_city | addComma}} {{pollingLocation.address_state}} {{pollingLocation.address_zip}}</span></a></td>
     </tr>
   </table>
 </section>

--- a/public/app/partials/feed-precinct.html
+++ b/public/app/partials/feed-precinct.html
@@ -24,7 +24,7 @@
     <tr id="earlyVoteSite{{$index}}" ng-repeat="earlyVoteSite in $data">
       <td id="earlyVoteSite-id{{$index}}" data-title="'ID'" sortable="'id'"><a href="{{$location.absUrl()}}/earlyvotesites/{{earlyVoteSite.id}}" data-title-text="ID"><span class="td-text">{{earlyVoteSite.id}}</span></a></td>
       <td id="earlyVoteSite-name{{$index}}" data-title="'Name'" sortable="'name'"><a href="{{$location.absUrl()}}/earlyvotesites/{{earlyVoteSite.id}}" data-title-text="Name"><span class="td-text">{{earlyVoteSite.name}}</span></a></td>
-      <td id="earlyVoteSite-address{{$index}}" data-title="'Address'" sortable="'address_city'"><a href="{{$location.absUrl()}}/earlyvotesites/{{earlyVoteSite.id}}" data-title-text="Address"><span class="td-text">{{earlyVoteSite.address_city}}, {{earlyVoteSite.address_state}} {{earlyVoteSite.address_zip}}</span></a></td>
+      <td id="earlyVoteSite-address{{$index}}" data-title="'Address'" sortable="'address_city'"><a href="{{$location.absUrl()}}/earlyvotesites/{{earlyVoteSite.id}}" data-title-text="Address"><span class="td-text">{{earlyVoteSite.address_city | addComma}} {{earlyVoteSite.address_state}} {{earlyVoteSite.address_zip}}</span></a></td>
     </tr>
   </table>
 </section>
@@ -70,7 +70,7 @@
     <tr id="pollingLocation{{$index}}" ng-repeat="pollingLocation in $data">
       <td id="pollingLocation-id{{$index}}" data-title="'ID'" sortable="'id'"><a href="{{$location.absUrl()}}/pollinglocations/{{pollingLocation.id}}" data-title-text="ID"><span class="td-text">{{pollingLocation.id}}</span></a></td>
       <td id="pollingLocation-name{{$index}}" data-title="'Name'" sortable="'address_location_name'"><a href="{{$location.absUrl()}}/pollinglocations/{{pollingLocation.id}}" data-title-text="Name"><span class="td-text">{{pollingLocation.address_location_name}}</span></a></td>
-      <td id="pollingLocation-address{{$index}}" data-title="'Address'" sortable="'address_city'"><a href="{{$location.absUrl()}}/pollinglocations/{{pollingLocation.id}}" data-title-text="Address"><span class="td-text">{{pollingLocation.address_city}}, {{pollingLocation.address_state}} {{pollingLocation.address_zip}}</span></a></td>
+      <td id="pollingLocation-address{{$index}}" data-title="'Address'" sortable="'address_city'"><a href="{{$location.absUrl()}}/pollinglocations/{{pollingLocation.id}}" data-title-text="Address"><span class="td-text">{{pollingLocation.address_city | addComma}} {{pollingLocation.address_state}} {{pollingLocation.address_zip}}</span></a></td>
     </tr>
   </table>
 </section>

--- a/public/app/partials/feed-precinctsplit.html
+++ b/public/app/partials/feed-precinctsplit.html
@@ -42,7 +42,7 @@
     <tr id="pollingLocation{{$index}}" ng-repeat="pollingLocation in $data">
       <td id="pollingLocation-id{{$index}}" data-title="'ID'" sortable="'id'"><a href="{{$location.absUrl()}}/pollinglocations/{{pollingLocation.id}}" data-title-text="ID"><span class="td-text">{{pollingLocation.id}}</span></a></td>
       <td id="pollingLocation-name{{$index}}" data-title="'Name'" sortable="'address_location_name'"><a href="{{$location.absUrl()}}/pollinglocations/{{pollingLocation.id}}" data-title-text="Name"><span class="td-text">{{pollingLocation.address_location_name}}</span></a></td>
-      <td id="pollingLocation-address{{$index}}" data-title="'Address'" sortable="'address_city'"><a href="{{$location.absUrl()}}/pollinglocations/{{pollingLocation.id}}" data-title-text="Address"><span class="td-text">{{pollingLocation.address_city}}, {{pollingLocation.address_state}} {{pollingLocation.address_zip}}</span></a></td>
+      <td id="pollingLocation-address{{$index}}" data-title="'Address'" sortable="'address_city'"><a href="{{$location.absUrl()}}/pollinglocations/{{pollingLocation.id}}" data-title-text="Address"><span class="td-text">{{pollingLocation.address_city | addComma}} {{pollingLocation.address_state}} {{pollingLocation.address_zip}}</span></a></td>
     </tr>
   </table>
 </section>

--- a/public/assets/js/app/filters.js
+++ b/public/assets/js/app/filters.js
@@ -234,4 +234,9 @@ angular.module('vipFilters', []).
       var complete = overview.info.count - errors;
       return Math.round(complete / overview.info.count * 100);
     }
+  }).
+  filter('addComma', function() {
+    return function(text) {
+      return (text === null || text === "") ? '' : text + ', ';
+    }
   });


### PR DESCRIPTION
[Pivotal Card](https://www.pivotaltracker.com/story/show/100052082). Adds a comma after text elements if they exist. This allows us to dynamically and correctly format addresses if they are partially or wholly incomplete.

Although the card is about a single instance, I tried finding wherever this may show up.