### PR TITLE
[WR] do not throw error if rabbitmq unavailable

### DIFF
--- a/notifications/queue.js
+++ b/notifications/queue.js
@@ -55,8 +55,8 @@ var url = 'amqp:' + config.notifications.host + ":" + config.notifications.port;
 var connect = function() {
   attempt += 1;
   if (attempt > 5) {
-    logger.error("Failed to connect to RabbitMQ!");
-    throw "RabbitMQ not available"
+    logger.log("failure", "Failed to connect to RabbitMQ!");
+    return;
   }
   logger.info("Attempt " + attempt + " to connect to: " + url);
 

--- a/notifications/queue.js
+++ b/notifications/queue.js
@@ -55,7 +55,7 @@ var url = 'amqp:' + config.notifications.host + ":" + config.notifications.port;
 var connect = function() {
   attempt += 1;
   if (attempt > 5) {
-    logger.log("failure", "Failed to connect to RabbitMQ!");
+    logger.log("alert", "Failed to connect to RabbitMQ!");
     return;
   }
   logger.info("Attempt " + attempt + " to connect to: " + url);


### PR DESCRIPTION
The logger error should be one of "failure," which should differentiate it from other errors.

[Pivotal Card](https://www.pivotaltracker.com/story/show/103420758)