### PR TITLE
only show one line in feeds if multiple elections

### DIFF
--- a/pg/queries.js
+++ b/pg/queries.js
@@ -25,13 +25,14 @@ var buildErrorQuery = function(joins, wheres) {
 }
 
 module.exports = {
-  feeds: "SELECT r.public_id, date(r.start_time) AS start_time, date(r.end_time) AS end_time, \
+  feeds: "SELECT DISTINCT ON (r.id) \
+                 r.public_id, date(r.start_time) AS start_time, date(r.end_time) AS end_time, \
                  CASE WHEN r.end_time IS NOT NULL THEN r.end_time - r.start_time END AS duration, \
                  r.complete, s.name AS state, e.election_type, date(e.date) AS election_date \
           FROM results r \
           LEFT JOIN states s ON s.results_id = r.id \
           LEFT JOIN elections e ON e.results_id = r.id \
-          ORDER BY r.start_time DESC;",
+          ORDER BY r.id DESC;",
   feedsForState: "SELECT r.public_id, date(r.start_time) AS start_time, \
                          CASE WHEN r.end_time IS NOT NULL THEN r.end_time - r.start_time END AS duration, \
                          r.complete, s.name AS state, e.election_type, date(e.date) AS election_date \


### PR DESCRIPTION
Instead of showing every election inside of a feed, show one line per feed on the `/feeds` page.