### PR TITLE
Use connection pool facility of node-postgres

### DIFF
--- a/pg/conn.js
+++ b/pg/conn.js
@@ -1,20 +1,16 @@
 var resp = require('./response.js');
+var pg = require('pg');
+var logger = (require('../logging/vip-winston')).Logger;
 
 module.exports = {
-  // Open the connection
-  openPostgres: function() {
-    var pg = require('pg');
-    var connString = process.env.DATABASE_URL;
-
-    var client = new pg.Client(connString);
-    client.connect();
-    return client;
-  },
-  // Close the connection
-  closePostgres: function(query, client, res) {
-    query.on("end", function (result) {
-      client.end();
-      resp.writeResponse(result.rows, res)
+  query: function(callback) {
+    pg.connect(process.env.DATABASE_URL, function(err, client, done) {
+      if (err) {
+        logger.crit(err);
+      } else {
+        callback(client);
+      }
+      done();
     });
   }
-}
+};

--- a/pg/util.js
+++ b/pg/util.js
@@ -1,21 +1,21 @@
 var conn = require('./conn.js');
+var resp = require('./response.js');
 
 module.exports = {
   simpleQueryResponder: function(sqlQuery, paramsFn) {
     return function(req, res) {
-      var query;
-      var client = conn.openPostgres();
-      if (paramsFn) {
-        query = client.query(sqlQuery, paramsFn(req));
-      } else {
-        query = client.query(sqlQuery);
-      };
 
-      query.on("row", function (row, result) {
-        result.addRow(row);
+      var callback = function(err, result) {
+        resp.writeResponse(result.rows, res);
+      }
+
+      conn.query(function(client) {
+        if (paramsFn) {
+          client.query(sqlQuery, paramsFn(req), callback);
+        } else {
+          client.query(sqlQuery, callback);
+        };
       });
-
-      conn.closePostgres(query, client, res);
     }
   },
   paramExtractor: function(params) {


### PR DESCRIPTION
Instead of creating a connection to postgres for each and every query, use [the connection pooling facility of node-postgres](https://github.com/brianc/node-postgres#client-pooling).

Fortunately, there are only three places where the bad style was being used.

Callback city.

Pivotal story: [103324962](https://www.pivotaltracker.com/story/show/103324962)