### PR TITLE
Fix sidebar data

### DIFF
--- a/public/app/partials/aside.html
+++ b/public/app/partials/aside.html
@@ -12,7 +12,7 @@
       <span class="important-errors">{{errorCount.important_error_count | number}} Total Errors in Feed</span>
       <br>
       {{errorCount.warning_error_count | number}} Warnings in Feed
-      <time id="feedDueDate" ng-if="getDueDateText(feedData.date)" class="due-date"><i class="fi-clock"></i> Final feed due {{getDueDateText(feedData.date)}}</time>
+      <time id="feedDueDate" ng-if="getDueDateText(election.date)" class="due-date"><i class="fi-clock"></i> Final feed due {{getDueDateText(election.date)}}</time>
       <a class="button button-download" href="{{errorReportUrl()}}">Download Full Error Report</a>
 
     </span>

--- a/public/app/partials/aside.html
+++ b/public/app/partials/aside.html
@@ -26,28 +26,11 @@
         <li><a id="sidebar-errors" class="is-started" href="{{urlForFeed('/errors')}}">Errors</a></li>
       </ul>
     </nav>
-    
+
     <a ng-if="feedIsApprovable" ng-click="exportFeedPost(feedData)" class="button-approve">Approve Feed</a>
     <div ng-if="!feedIsApprovable" class="button-errors disabled">Feed Cannot Be Approved</div>
 
     <p align="center" class="helper">Fatal Errors must be resolved before the feed can be approved.</p>
   </div>
-
-  <div class="contact-wrap">
-    <h2>Feed Contact</h2>
-    <div ng-show="feedData.feed_contact && feedData.feed_contact!=null" class="vcard">
-      <span ng-show="feedData.feed_contact.name" id="feed_contact_name" class="fn">{{feedData.feed_contact.name}}</span>
-      <span ng-show="feedData.feed_contact.title" id="feed_contact_title" class="title">{{feedData.feed_contact.title}}</span>
-      <span ng-show="feedData.feed_contact.tel" id="feed_contact_tel" class="tel">P: {{feedData.feed_contact.phone}}</span>
-      <span ng-show="feedData.feed_contact.fax" id="feed_contact_fax" class="fax">F: {{feedData.feed_contact.fax}}</span>
-      <span ng-show="feedData.feed_contact.email" id="feed_contact_email" class="email"><a href="mailto:{{feedData.feed_contact.email}}">{{feedData.feed_contact.email}}</a></span>
-    </div>
-
-    <div ng-show="feedData.feed_contact ==null" class="vcard">
-      N/A
-    </div>
-
-  </div>
-
   </div>
 </div>

--- a/public/app/partials/aside.html
+++ b/public/app/partials/aside.html
@@ -1,7 +1,7 @@
 <header class="feed-title" ng-click="toggleAsideFunc()">
   <div class="wrapper">
 
-    <h2>{{feedData.title}}<i class="fi-minus" ng-class="{'fi-plus': toggleAside}"><span class="move">(open navigation)</span></i></h2>
+    <h2>{{getBreadCrumbs()[0]["name"]}}<i class="fi-minus" ng-class="{'fi-plus': toggleAside}"><span class="move">(open navigation)</span></i></h2>
 
   </div>
 </header>

--- a/public/assets/css/module.scss
+++ b/public/assets/css/module.scss
@@ -580,6 +580,7 @@ aside {
   cursor: pointer;
 
   @include bp(c12) {
+    display: none;
     cursor: default;
     padding-top: $base-sm;
   }
@@ -596,9 +597,6 @@ aside {
     position: absolute;
     right: 0;
     top: 0;
-    @include bp(c12) {
-      display: none;
-    }
   }
 }
 

--- a/public/assets/js/app/app.js
+++ b/public/assets/js/app/app.js
@@ -293,7 +293,7 @@ vipApp.run(function ($rootScope, $appService, $location, $httpBackend, $appPrope
     $rootScope.getDueDateText = function(date){
 
       if(date){
-        var dueDate = moment(date, "YYYY-MM-DD").subtract($rootScope.$appProperties.electionDueDateWeeksInAdvance, 'weeks');
+        var dueDate = moment(date, "YYYY-MM-DD").subtract(23, 'days');
         var dueDateText = moment(dueDate).utc().format('YYYY-MM-DD');
         return dueDateText;
       } else {

--- a/public/assets/js/app/controllers/asideController.js
+++ b/public/assets/js/app/controllers/asideController.js
@@ -1,6 +1,12 @@
 function AsideCtrl($scope, $rootScope, $feedDataPaths, $routeParams) {
   var feedid = $routeParams.vipfeed;
 
+  $feedDataPaths.getResponse({ path: '/db/feeds/' + feedid + '/election',
+                               scope: $rootScope,
+                               key: "election",
+                               errorMessage: "Could not retrieve Election."},
+                             function(result) { $rootScope.election = result[0]; });
+
   $feedDataPaths.getResponse({ path: '/db/feeds/' + feedid + '/error-total-count',
                                scope: $rootScope,
                                key: "errorCount",


### PR DESCRIPTION
* Calculate feed due date from the election date for the feed
* Take title from breadcrumbs (it's how everywhere else has that title)
* Remove feed contact

Additionally (from discussions with Maria during the process):

* Only show feed title in the sidebar in "mobile"
* Make the two different feed "due date" calculations match up

Pivotal story: [105257072](https://www.pivotaltracker.com/story/show/105257072)