### PR TITLE
Use file storage for session information

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,5 @@ upload
 
 node_modules
 feeds
+
+sessions

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ public/assets/js/lib/*
 !/public/assets/js/lib/leaflet
 
 metis@.service
+
+sessions

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ For more information see the [Crowd Admin Guide](https://confluence.atlassian.co
 
 ## Running Karma Unit Tests
 
+WARNING: This is out of date and cannot be run.
+
 1. install karma
 ```
 npm install karma
@@ -62,9 +64,11 @@ Karma is configured to use chrome as the default browser.
 
 ## Running Functional Tests
 
+Be sure to run the Getting Started commands above.
+
 1. Give permissions to public/test/RunFunctional.sh
 ```
-chmod +x RunFunctional.sh
+chmod +x public/test/RunFunctional.sh
 ```
 2. Execute the script
 ```

--- a/app.js
+++ b/app.js
@@ -36,6 +36,10 @@ var redirectHttps = function(req, res, next) {
   }
 };
 
+// FileSession
+var FileStore = require('session-file-store')(express.session);
+var sessionFileStore = new FileStore(config.session);
+
 // all environments
 app.use(express.favicon(config.web.favicon));
 app.use(express.logger(config.web.loglevel));
@@ -43,7 +47,7 @@ app.use(express.json());
 app.use(express.urlencoded());
 app.use(express.methodOverride());
 app.use(express.cookieParser());
-app.use(express.session({ secret: config.web.sessionsecret }));
+app.use(express.session({ store: sessionFileStore, secret: config.web.sessionsecret }));
 app.use(passport.initialize());
 app.use(passport.session());
 

--- a/config.js
+++ b/config.js
@@ -28,6 +28,11 @@ config.web = {
   SSLCert: '/vipdata/certs/*_votinginfoproject_org_chained.crt'
 };
 
+config.session = {
+  ttl: 3600,
+  reapInterval: 3600
+}
+
 config.auth = {
   uselocalauth: function() {
     return !config.auth.apiKey ||

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "aws-sdk": "~2.0.0-rc13",
     "csv": "~0.4.0",
     "express": "3.4.4",
+    "session-file-store": "0.0.20",
     "geojson": "~0.1.5",
     "interval-query": "~0.3.0",
     "meld": "~1.3.1",


### PR DESCRIPTION
Replace in-memory MemoryStore with FileStore.

Sessions are small files (160–238 bytes), reaped every hour. And the number of concurrent active sessions is expected to be very, very low.

Pivotal story: [103628864](https://www.pivotaltracker.com/story/show/103628864)