### PR TITLE
Add time to "Loaded on" column of feeds list

### DIFF
--- a/pg/queries.js
+++ b/pg/queries.js
@@ -26,7 +26,7 @@ var buildErrorQuery = function(joins, wheres) {
 
 module.exports = {
   feeds: "SELECT DISTINCT ON (r.id) \
-                 r.public_id, date(r.start_time) AS start_time, date(r.end_time) AS end_time, \
+                 r.public_id, r.start_time, date(r.end_time) AS end_time, \
                  CASE WHEN r.end_time IS NOT NULL THEN r.end_time - r.start_time END AS duration, \
                  r.complete, s.name AS state, e.election_type, date(e.date) AS election_date \
           FROM results r \

--- a/public/app/partials/feeds.html
+++ b/public/app/partials/feeds.html
@@ -41,7 +41,7 @@
     </td>
     <td data-title="'Loaded On'" sortable="'date_loaded'">
       <a ng-class="{'disabled-row': !feed.complete && !feed.end_time, 'disabled-row-failed': !feed.complete && feed.end_time}" href="#/feeds/{{feed.public_id}}" data-title-text="Loaded On"><span class="td-text">
-      {{feed.start_time.slice(0,10) | date:'longDate'}}
+      {{feed.start_time | date:'longDate'}} at {{feed.start_time | date:'shortTime'}}
       <span ng-if="!feed.start_time">&nbsp;</span>
       </span></a>
     </td>


### PR DESCRIPTION
Query updated to no longer drop the time portion of the `r.start_time`.

Pivotal story: [107533056](https://www.pivotaltracker.com/story/show/107533056)