### PR TITLE
Fix display of election date in source view

### DIFF
--- a/public/app/partials/feed-source.html
+++ b/public/app/partials/feed-source.html
@@ -37,7 +37,7 @@
     <dt class="key">Name:</dt>
     <dd id="election-name" class="value">{{feedElection.name}}</dd>
     <dt class="key">Date:</dt>
-    <dd id="election-date" class="value">{{feedElection.date | date}}</dd>
+    <dd id="election-date" class="value">{{feedElection.date.slice(0,10) | date}}</dd>
     <dt class="key">Election Type:</dt>
     <dd id="election-type" class="value">{{feedElection.election_type}}</dd>
     <dt class="key">Statewide</dt>


### PR DESCRIPTION
The `date` filter from Angular behaves in a way such that dates from the database, like '2014-11-04T00:00:00Z', would be treated as if the time mattered, converting it to the browser's timezone when displaying the date. This resulted in elections displaying the incorrect date if the user's browser was west of the meridian (which is where the United States is). `{{'2014-11-04T00:00:00Z' | date}}` renders "Nov 3, 2014".

Trimming off the time portion of the date string makes Angular ignore timezone considerations and "2014-11-04" renders as "Nov 4, 2014".

In recent releases of Angular, the `date` filter takes an extra argument for the timezone the date should be rendered as, but we're on 1.2.

Pivotal story: [111421672](https://www.pivotaltracker.com/story/show/111421672)