### PR TITLE
Send email when xml feed completes

### DIFF
--- a/notifications/content.js
+++ b/notifications/content.js
@@ -15,6 +15,14 @@ module.exports = {
            "<p>If you have any questions, please contact <a href='mailto:vip@democracy.works'>vip@democracy.works</a>.</p>" +
            "<p>Thank you!</p>";
   },
+  v5processedFeed: function(message, recipient, group) {
+    return "<p>" + recipient.givenName + ",</p>" +
+           "<p>The data you provided for " + group.description + "'s election has been processed.</p>" +
+           "<p>Please click the link below for an error report.</p>" +
+           "<p><a href='https://" + baseUrl + "/db/feeds/" + message[":public-id"] + "/xml/errors/report'>Go to the Data Dashboard</a></p>" +
+           "<p>If you have any questions, please contact <a href='mailto:vip@democracy.works'>vip@democracy.works</a>.</p>" +
+           "<p>Thank you!</p>";
+  },
   errorDuringProcessing: function(message) {
     return 'It looks like a feed failed during processing. Here\'s the information we got: \
             \nMessage we got: ' + JSON.stringify(message);

--- a/notifications/sender.js
+++ b/notifications/sender.js
@@ -92,18 +92,19 @@ module.exports = {
                         WHERE r.public_id = $1";
 
     var publicId = message[":public-id"];
+
     if (!publicId) {
-      logger.error('No Public ID listed.');
+      logger.info('[ERROR] No Public ID listed.');
       notifyGroup(message, config.email.adminGroup, messageOptions.errorDuringProcessing);
     } else {
       pg.connect(process.env.DATABASE_URL, function(err, client, done) {
-        if (err) return logger.error('Could not connect to PostgreSQL. Error fetching client from pool: ', err);
+        if (err) return logger.info('[ERROR] Could not connect to PostgreSQL. Error fetching client from pool: ', err);
 
         client.query(vip_id_query, [publicId], function(err, result) {
           done();
 
           if (err || result.rows.length == 0) {
-            logger.error('No feed found or connection issue.');
+            logger.info('[ERROR] No feed found or connection issue.');
             notifyGroup(message, config.email.adminGroup, messageOptions.errorDuringProcessing);
           } else {
             notifyGroup(message, result.rows[0].vip_id, messageOptions[messageType]);

--- a/pg/csv.js
+++ b/pg/csv.js
@@ -65,7 +65,8 @@ var xmlTreeValidationQuery =
  FROM xml_tree_validations v \
  LEFT JOIN xml_tree_values x \
         ON x.path = subpath(v.path,0,4) || 'id' AND x.results_id = v.results_id \
- WHERE v.results_id = $1";
+ INNER JOIN results r ON r.id = v.results_id \
+ WHERE r.public_id = $1";
 
 var xmlTreeValidationErrorReport = function(req, res) {
   var header = ["Feed", "Severity", "Scope", "Path", "ID", "Error Type", "Error Data"];


### PR DESCRIPTION
The 3.0 and 5.0 feeds have results in different places, so in this PR, we take the message announcing a successful run and looks in both places to find the result before sending an email announcing the details of the run.

This is a step that's required to be finished before we can merge data-processor's `import-5.0-xml-into-postgres` branch.

[Pivotal card](https://www.pivotaltracker.com/story/show/116162051)