### PR TITLE
Include error counts in 5.1 feed overviews

### DIFF
--- a/pg/services.js
+++ b/pg/services.js
@@ -50,6 +50,7 @@ function registerPostgresServices (app) {
   ///////// Version 5.1 /////////
   app.get('/db/feeds/:feedid/xml/overview', pg51.feedOverview);
   app.get('/db/feeds/:feedid/xml/errors/report', csv.xmlTreeValidationErrorReport);
+  app.get('/db/feeds/:feedid/xml/error-total-count', pg51.totalErrors);
 
   ///////// Version 3.0 /////////
   app.get('/db/v3/feeds/:feedid/election', pg.v3.getFeedElection);

--- a/pg/v5_1_queries.js
+++ b/pg/v5_1_queries.js
@@ -12,6 +12,16 @@ var overviewQuery = "select r.id, \
                                            and xtv_date.simple_path = 'VipObject.Election.Date' \
                      where r.public_id = $1;"
 
+var totalErrorsQuery = "select (select count(v.*) \
+                                from xml_tree_validations v \
+                                where r.id = v.results_id \
+                                  and v.severity in ('fatal', 'critical', 'errors')) as total_errors, \
+                               (select count(v.*) \
+                                from xml_tree_validations v \
+                                where r.id = v.results_id \
+                                  and v.severity = 'warnings') as total_warnings \
+                        from results r where r.public_id = $1;"
 module.exports = {
   feedOverview: util.simpleQueryResponder(overviewQuery, util.paramExtractor()),
+  totalErrors: util.simpleQueryResponder(totalErrorsQuery, util.paramExtractor()),
 }

--- a/public/app/partials/5.1/aside.html
+++ b/public/app/partials/5.1/aside.html
@@ -9,9 +9,9 @@
   <div class="wrapper">
   <div class="aside-nav">
     <span class="button-errors">
-      <span class="important-errors">{{errorCount.important_error_count | number}} Total Errors in Feed</span>
+      <span class="important-errors">{{errorCount.total_errors | number}} Total Errors in Feed</span>
       <br>
-      {{errorCount.warning_error_count | number}} Warnings in Feed
+      {{errorCount.total_warnings | number}} Warnings in Feed
       <time id="feedDueDate" ng-if="getDueDateText(election.date)" class="due-date"><i class="fi-clock"></i> Final feed due {{getDueDateText(election.date)}}</time>
       <a class="button button-download" href="{{errorReport}}">Download full error report</a>
 

--- a/public/assets/js/app/controllers/5.1/v5AsideController.js
+++ b/public/assets/js/app/controllers/5.1/v5AsideController.js
@@ -1,5 +1,14 @@
-function v5AsideController($scope, $rootScope) {
+'use strict';
+function v5AsideController($scope, $rootScope, $feedDataPaths, $routeParams) {
+  var publicId = $rootScope.publicId = $routeParams.vipfeed;
+
   $rootScope.feedURL = function(path) {
     return "#/5.1/feeds/" + $rootScope.publicId + path;
   };
+
+  $feedDataPaths.getResponse({path: '/db/feeds/' + publicId + '/xml/error-total-count',
+                              scope: $rootScope,
+                              key: "errorCount",
+                              errorMessage: "Could not retrieve Feed Error Count."},
+                             function(result) { $rootScope.errorCount = result[0]; });
 }

--- a/public/index.html
+++ b/public/index.html
@@ -168,12 +168,12 @@
       <div ng-switch on="$location.url().split('/')[1]">
         <div ng-switch-when="5.1">
           <aside class="feed-meta"
-                 ng-if="$location.url()!='/feeds' && pageHeader.section==='feeds' && pageHeader.title!=='Feeds'"
+                 ng-if="$location.url() !== '/feeds' && pageHeader.section === 'feeds' && pageHeader.title !== 'Feeds'"
                  ng-controller="v5AsideController" ng-include src="'app/partials/5.1/aside.html'"></aside>
         </div>
         <div ng-switch-default>
           <aside class="feed-meta"
-                 ng-if="$location.url()!='/feeds' && pageHeader.section==='feeds' && pageHeader.title!=='Feeds'"
+                 ng-if="$location.url() !== '/feeds' && pageHeader.section === 'feeds' && pageHeader.title !== 'Feeds'"
                  ng-controller="AsideCtrl"
                  ng-include src="'app/partials/aside.html'"></aside>
         </div>

--- a/public/index.html
+++ b/public/index.html
@@ -167,7 +167,9 @@
 
       <div ng-switch on="$location.url().split('/')[1]">
         <div ng-switch-when="5.1">
-          <aside class="feed-meta" ng-controller="v5AsideController" ng-include src="'app/partials/5.1/aside.html'"></aside>
+          <aside class="feed-meta"
+                 ng-if="$location.url()!='/feeds' && pageHeader.section==='feeds' && pageHeader.title!=='Feeds'"
+                 ng-controller="v5AsideController" ng-include src="'app/partials/5.1/aside.html'"></aside>
         </div>
         <div ng-switch-default>
           <aside class="feed-meta"


### PR DESCRIPTION
This PR adds high level info about errors in your feed. **Total Errors in Feed** are a combination of errors with severities of `fatal`, `critical`, and `errors`; **Warnings in Feed** are just the `warnings`. See the [Pivotal card](https://www.pivotaltracker.com/story/show/123263841) for more infomation.

You might look at `index.html` and say to yourself: "*Why would we add an `ng-if` directive? We don't need it here!*" If the world were a sane place, you'd be right, but the world is not always so. It turns out that if you omit this directive, `V5AsideController` will be called *before* `FeedOverview51Ctrl`, and `$routeParams.vipfeed` will be `undefined`. You won't be able to request any errors with an undefined `public_id`! 

"*There must be a better way!*", I can hear you saying, and I hope you're right. Let's talk about that part and see if we can find the better way.