### PR TITLE
Add Voting Locations errors to 5.1 feed overview

### DIFF
--- a/pg/services.js
+++ b/pg/services.js
@@ -49,6 +49,7 @@ function registerPostgresServices (app) {
 
   ///////// Version 5.1 /////////
   app.get('/db/feeds/:feedid/xml/overview', pg51.feedOverview);
+  app.get('/db/feeds/:feedid/xml/localityOverview', pg51.localityOverview);
   app.get('/db/feeds/:feedid/xml/errors/report', csv.xmlTreeValidationErrorReport);
   app.get('/db/feeds/:feedid/xml/error-total-count', pg51.totalErrors);
 

--- a/pg/v5_1_queries.js
+++ b/pg/v5_1_queries.js
@@ -1,4 +1,8 @@
+var conn = require('./conn.js');
+var queries = require('./queries.js');
+var resp = require('./response.js');
 var util = require('./util.js');
+
 var overviewQuery = "select r.id, \
                      xtv_state.value as state_name, \
                      xtv_type.value as election_type, \
@@ -10,7 +14,7 @@ var overviewQuery = "select r.id, \
                                            and xtv_type.path ~ 'VipObject.*.Election.*.ElectionType.*.Text.0' \
                      left join xml_tree_values xtv_date on xtv_date.results_id = r.id \
                                            and xtv_date.simple_path = 'VipObject.Election.Date' \
-                     where r.public_id = $1;"
+                     where r.public_id = $1;";
 
 var totalErrorsQuery = "select (select count(v.*) \
                                 from xml_tree_validations v \
@@ -20,8 +24,44 @@ var totalErrorsQuery = "select (select count(v.*) \
                                 from xml_tree_validations v \
                                 where r.id = v.results_id \
                                   and v.severity = 'warnings') as total_warnings \
-                        from results r where r.public_id = $1;"
+                        from results r where r.public_id = $1;";
+
+var overviewTableRow = function(row, type, dbTable, link) {
+  return {element_type: type,
+          count: row[dbTable + '_count'],
+          complete_pct: row[dbTable + '_completion'],
+          error_count: row[dbTable + '_errors'],
+          link: link};
+};
+
+var getLocalityOverview = function(req, res) {
+  var feedid = req.params.feedid;
+  conn.query(function(client) {
+    client.query("SELECT s.* FROM v5_statistics s \
+                  INNER JOIN results r ON s.results_id = r.id \
+                  WHERE r.public_id=$1",
+                 [decodeURIComponent(feedid)],
+                 function(err, result) {
+                     var row = result.rows[0];
+                     if (row !== undefined){
+                         var tables = {
+                             pollingLocations: [
+                                 overviewTableRow(row, 'Street Segments', 'street_segment', '#/5.1/feeds/' + feedid + '/overview/street_segments/errors'),
+                                 overviewTableRow(row, 'State', 'state', '#/5.1/feeds/' + feedid + '/overview/states/errors'),
+                                 overviewTableRow(row, 'Precincts', 'precinct', '#/5.1/feeds/' + feedid + '/overview/precincts/errors'),
+                                 overviewTableRow(row, 'Polling Location', 'polling_location', '#/5.1/feeds/' + feedid + '/overview/polling_locations/errors'),
+                                 overviewTableRow(row, 'Localities', 'locality', '#/5.1/feeds/' + feedid + '/overview/localities/errors'),
+                                 overviewTableRow(row, 'Hours Open', 'hours_open', '#/5.1/feeds/' + feedid + '/overview/hours_open/errors')
+                             ]
+                         };
+                         resp.writeResponse([tables], res);
+                     }
+                 });
+  });
+};
+
 module.exports = {
-  feedOverview: util.simpleQueryResponder(overviewQuery, util.paramExtractor()),
-  totalErrors: util.simpleQueryResponder(totalErrorsQuery, util.paramExtractor()),
+    feedOverview: util.simpleQueryResponder(overviewQuery, util.paramExtractor()),
+    localityOverview: getLocalityOverview,
+    totalErrors: util.simpleQueryResponder(totalErrorsQuery, util.paramExtractor()),
 }

--- a/public/app/partials/5.1/feed-overview.html
+++ b/public/app/partials/5.1/feed-overview.html
@@ -1,2 +1,91 @@
-<div>
+<i id="feed-overview-content"></i>
+
+<div class="overview-wrap">
+  <section class="data-group data-module started">
+    <header class="data-group-header">
+      <h2>Voting Locations</h2>
+      <span ng-if="!overviewData" class="more-detail is-loading"></span>
+
+      <a id="state-link"
+         ng-if="overviewData.pollingLocations"
+         class="more-detail"
+         href="{{$location.absUrl()}}/election/state">More Detail</a>
+    </header>
+
+    <section class="data-group data-module">
+      <div ng-if="!overviewData">
+        <br/>
+        <span class="is-loading"></span>
+      </div>
+
+      <table id="pollingTable"
+             class="overview associations"
+             template-pagination="pollingPagination"
+             ng-show="overviewData"
+             ng-table="pollingLocationsTable">
+
+        <tr id="pollingLocation{{$index}}" ng-repeat="pollingLocation in $data">
+          <td data-title="'Element Type'"
+              sortable="'element_type'"
+              id="pollingLocation-element-type{{$index}}"
+              class="element-type">
+            <span data-title-text="Element Type">{{pollingLocation.element_type}}</span>
+          </td>
+
+          <td data-title="'Amount'"
+              sortable="'count'"
+              id="pollingLocation-amount{{$index}}"
+              class="numeric amount">
+            <span data-title-text="Amount">{{pollingLocation.count | number}}</span></td>
+
+          <td data-title="'Completion'"
+              sortable="'complete_pct'"
+              id="pollingLocation-complete{{$index}}"
+              class="completion">
+            <div data-title-text="Completion" class="completeness">
+              <span class="complete-{{pollingLocation.complete_pct}}"></span>
+              <div class="counter">
+                {{pollingLocation.complete_pct | number}}% <span class="counter-text">complete</span>
+              </div>
+            </div>
+          </td>
+
+          <td data-title="'Errors'"
+              sortable="'error_count'"
+              id="pollingLocation-errors{{$index}}"
+              class="numeric element-errors">
+            <a data-title-text="Errors"
+               title="View the Errors"
+               ng-class="{default_pointer: pollingLocation.error_count === 0}"
+               href="{{pollingLocation.error_count === 0 ? 'javascript: void(0);' : pollingLocation.link}}">
+              <div errorvalue="{{pollingLocation.error_count}}"
+                   ng-class="{none: pollingLocation.error_count===0}"
+                   class="errors">
+                {{pollingLocation.error_count | number}}
+                <span class="error-text" ng-if="pollingLocation.error_count === 1">error</span>
+                <span class="error-text" ng-if="pollingLocation.error_count != 1">errors</span>
+                <span ng-if="pollingLocation.error_count === 0">
+                  <i class="fi-check"></i>
+                </span><span ng-if="pollingLocation.error_count != 0">
+                  <i class="fi-alert"></i>
+                </span>
+              </div>
+            </a>
+          </td>
+        </tr>
+      </table>
+
+      <script type="text/ng-template" id="pollingPagination">
+        <ul class="pagination ng-cloak">
+          <li ng-repeat="page in pages"
+              ng-class="{'ng-hide': page.type == 'prev' || page.type == 'next'}">
+            <a id="feedsPage{{$index}}"
+               ng-class="{'is-active': page.number == pollingLocationsTable.page()}"
+               ng-click="pollingLocationsTable.page(page.number)"
+               href="">{{page.number}}</a>
+          </li>
+        </ul>
+      </script>
+    </section>
+  </section>
 </div>

--- a/public/assets/js/app/controllers/5.1/feedOverview51Controller.js
+++ b/public/assets/js/app/controllers/5.1/feedOverview51Controller.js
@@ -1,19 +1,35 @@
 'use strict';
 
-function FeedOverview51Ctrl($scope, $rootScope, $feedDataPaths, $routeParams) {
+function FeedOverview51Ctrl($scope, $rootScope, $feedDataPaths, $routeParams,
+                            $location, $appProperties, $filter, ngTableParams) {
   var publicId = $rootScope.publicId = $routeParams.vipfeed;
   $rootScope.errorReport = "/db/feeds/" + publicId + "/xml/errors/report";
 
-  $feedDataPaths.getResponse({path: '/db/feeds/' + publicId + '/xml/overview',
-                              scope:  $rootScope,
-                              key: 'overviewData',
-                              errorMessage: 'Cound not retrieve Feed Overview Data.'},
-                             function(result) {
-                               var row = result[0];
-                               $scope.pageTitle = row.election_date + " " +
-                                                  row.election_type + " " +
-                                                  row.state_name;
-                               $rootScope.pageTitle = $scope.pageTitle;
-                               $rootScope.setPageHeader($scope.pageTitle, [], 'feeds', null, null);
-                             });
+  $feedDataPaths
+    .getResponse({path: '/db/feeds/' + publicId + '/xml/overview',
+                  scope:  $rootScope,
+                  key: 'overviewData',
+                  errorMessage: 'Cound not retrieve Feed Overview Data.'},
+                 function(result) {
+                   var row = $rootScope.overviewData = result.shift();
+                   $scope.pageTitle = row.election_date + " " +
+                     row.election_type + " " +
+                     row.state_name;
+                   $rootScope.pageTitle = $scope.pageTitle;
+                   $rootScope.setPageHeader($scope.pageTitle, [], 'feeds', null, null);
+                 });
+
+  $feedDataPaths
+    .getResponse({path: 'db/feeds/' + publicId + '/xml/localityOverview',
+                  scope: $rootScope,
+                  key: 'pollingLocations',
+                  errorMessage: 'Could not get locality data'},
+                 function(result) {
+                   var row = $rootScope.pollingLocationsData = result.shift();
+                   $scope.pollingLocationsTable =
+                     $rootScope.createTableParams(ngTableParams, $filter,
+                                                  row.pollingLocations,
+                                                  $appProperties.lowPagination,
+                                                  { element_type: 'asc' });
+                 });
 }


### PR DESCRIPTION
This PR is for displaying those errors that are related to Voting Locations. A blocking [data-processor PR](https://github.com/votinginfoproject/data-processor/pull/205) covers the work of building a summary table for the views, and should be deployed first, and any already processed feeds summarized by hand.

[Pivotal Card](https://www.pivotaltracker.com/story/show/123274641)