### PR TITLE
Increase postgres timeouts

### DIFF
--- a/app.js
+++ b/app.js
@@ -97,5 +97,5 @@ pg.connect(connString, function(err, client, done) {
     return logger.error('Could not connect to PostgreSQL. Error fetching client from pool: ', err);
   }
 
-  logger.info('Connected to PostgreSQL. May your queries terminate before a 5 minute timeout.');
+  logger.info('Connected to PostgreSQL. May your queries terminate before a 3 minute timeout.');
 });

--- a/app.js
+++ b/app.js
@@ -97,5 +97,5 @@ pg.connect(connString, function(err, client, done) {
     return logger.error('Could not connect to PostgreSQL. Error fetching client from pool: ', err);
   }
 
-  logger.info('Connected to PostgreSQL.');
+  logger.info('Connected to PostgreSQL. May your queries terminate before a 5 minute timeout.');
 });

--- a/logging/vip-winston.js
+++ b/logging/vip-winston.js
@@ -3,9 +3,18 @@ var winston = require('winston');
 
 require('winston-syslog').Syslog;
 
-winston.setLevels(winston.config.syslog.levels);
+winston.setLevels({
+  emerg: 7,
+  alert: 6,
+  crit: 5,
+  error: 4,
+  warning: 3,
+  notice: 2,
+  info: 1,
+  debug: 0
+});
 
-if(config.log.syslog.host && config.log.syslog.port) {
+if (config.log.syslog.host && config.log.syslog.port) {
   winston.add(winston.transports.Syslog, config.log.syslog);
 } else {
   winston.info("Not logging to Syslog");

--- a/notifications/sender.js
+++ b/notifications/sender.js
@@ -102,17 +102,17 @@ module.exports = {
     var publicId = message[":public-id"];
 
     if (!publicId) {
-      logger.info('[ERROR] No Public ID listed.');
+      logger.error('No Public ID listed.');
       notifyGroup(message, config.email.adminGroup, messageOptions.errorDuringProcessing);
     } else {
       pg.connect(process.env.DATABASE_URL, function(err, client, done) {
-        if (err) return logger.info('[ERROR] Could not connect to PostgreSQL. Error fetching client from pool: ', err);
+        if (err) return logger.error('Could not connect to PostgreSQL. Error fetching client from pool: ', err);
 
         client.query(vip_id_query, [publicId], function(err, result) {
           done();
 
           if (err || result.rows.length == 0) {
-            logger.info('[ERROR] No feed found or connection issue.');
+            logger.error('No feed found or connection issue.');
             notifyGroup(message, config.email.adminGroup, messageOptions.errorDuringProcessing);
           } else {
             if (result.rows[0].v5_vip_id && messageType === 'processedFeed') {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "passport": "~0.2.2",
     "passport-stormpath": "0.2.4",
     "passport-local": "1.0.0",
-    "pg": "^4.3.0",
+    "pg": "^6.1.0",
     "pretty-data": "~0.40.0",
     "shapefile": "~0.2.0",
     "stormpath": "^0.11.1",

--- a/pg/conn.js
+++ b/pg/conn.js
@@ -9,7 +9,7 @@ var config = {
   password: process.env.DB_ENV_POSTGRES_PASSWORD,
   port: process.env.DB_PORT_5432_TCP_PORT,
   max: 10, // clients in the connection pool
-  idleTimeoutMillis: 500000
+  idleTimeoutMillis: 300000
 };
 
 var pool = new pg.Pool(config);
@@ -26,8 +26,8 @@ var queryFromPool = function(callback) {
 });
 
   pool.on('error', function (err, client) {
-    logger.crit('*** WOWZERS *** idle client error', err.message, err.stack);
-    console.error('*** BONKERS *** idle client error', err.message, err.stack);
+    logger.error('idle client error', err.message, err.stack);
+    console.error('idle client error', err.message, err.stack);
   });
 }
 

--- a/pg/conn.js
+++ b/pg/conn.js
@@ -3,6 +3,7 @@ var pg = require('pg');
 var logger = (require('../logging/vip-winston')).Logger;
 
 var config = {
+  host: process.env.DB_PORT_5432_TCP_ADDR,
   user: process.env.DB_ENV_POSTGRES_USER,
   database: process.env.DB_ENV_POSTGRES_DATABASE,
   password: process.env.DB_ENV_POSTGRES_PASSWORD,

--- a/pg/conn.js
+++ b/pg/conn.js
@@ -16,8 +16,8 @@ var pool = new pg.Pool(config);
 
 var queryFromPool = function(callback) {
   pool.connect(function(err, client, done) {
-    if(err) {
-      return console.error('error fetching client from pool', err);
+    if (err) {
+      logger.crit('error fetching client from pool', err);
     }
     else {
       callback(client);

--- a/pg/conn.js
+++ b/pg/conn.js
@@ -27,7 +27,6 @@ var queryFromPool = function(callback) {
 
   pool.on('error', function (err, client) {
     logger.error('idle client error', err.message, err.stack);
-    console.error('idle client error', err.message, err.stack);
   });
 }
 

--- a/pg/conn.js
+++ b/pg/conn.js
@@ -2,15 +2,34 @@ var resp = require('./response.js');
 var pg = require('pg');
 var logger = (require('../logging/vip-winston')).Logger;
 
+var config = {
+  user: process.env.DB_ENV_POSTGRES_USER,
+  database: process.env.DB_ENV_POSTGRES_DATABASE,
+  password: process.env.DB_ENV_POSTGRES_PASSWORD,
+  port: process.env.DB_PORT_5432_TCP_PORT,
+  max: 10, // clients in the connection pool
+  idleTimeoutMillis: 500000
+};
+
+var pool = new pg.Pool(config);
+
+var queryFromPool = function(callback) {
+  pool.connect(function(err, client, done) {
+    if(err) {
+      return console.error('error fetching client from pool', err);
+    }
+    else {
+      callback(client);
+    }
+    done();
+});
+
+  pool.on('error', function (err, client) {
+    logger.crit('*** WOWZERS *** idle client error', err.message, err.stack);
+    console.error('*** BONKERS *** idle client error', err.message, err.stack);
+  });
+}
+
 module.exports = {
-  query: function(callback) {
-    pg.connect(process.env.DATABASE_URL, function(err, client, done) {
-      if (err) {
-        logger.crit(err);
-      } else {
-        callback(client);
-      }
-      done();
-    });
-  }
+  query: queryFromPool
 };

--- a/pg/csv.js
+++ b/pg/csv.js
@@ -59,7 +59,9 @@ var errorReport = function(innerJoins, where, params, scope) {
         });
 
         query.on("error", function(e) {
-          logger.info("[ERROR] Generating an error report for feed '" + feedid + "' caused '" + e +"'");
+          logger.info("[ERROR] Generating an error report for '" + feedid + "' caused " + e.message);
+          // If the query doesn't return anything before we hit our connection's
+          // timeout, we'll only have added CSV headers to the response.
           res.end();
         });
       });

--- a/pg/csv.js
+++ b/pg/csv.js
@@ -59,7 +59,7 @@ var errorReport = function(innerJoins, where, params, scope) {
         });
 
         query.on("error", function(e) {
-          logger.info("[ERROR] Generating an error report for '" + feedid + "' caused " + e.message);
+          logger.error("Generating an error report for '" + feedid + "' caused " + e.message);
           // If the query doesn't return anything before we hit our connection's
           // timeout, we'll only have added CSV headers to the response.
           res.end();


### PR DESCRIPTION
Some states have feeds with millions of errors in their street segment
files. The queries and CSV generation take more time that we were
allowing, and when the timeout hit, we'd return them a file with only
header rows.

Three minutes seems like a lot, but it allows the queries to finish. On my dev machine, runtime is ≈ 2.5 minutes; on the staging nodes it is ≈ 1 minute.