### PR TITLE
Count the actual number of polling locations

### DIFF
--- a/pg/queries.js
+++ b/pg/queries.js
@@ -358,15 +358,16 @@ module.exports = {
                                                     INNER JOIN validations v ON v.results_id = l.results_id AND v.scope = 'election-administrations' AND v.identifier = ea.id \
                                                     INNER JOIN results r ON r.id = l.results_id \
                                                     WHERE r.public_id=$1 AND l.id=$2;",
+
     localityOverviewPollingLocations: "SELECT (ppl.count + pspl.count) AS count \
-                                       FROM (SELECT COUNT(pl.*)::int AS count \
+                                       FROM (SELECT COUNT(DISTINCT pl.*)::int AS count \
                                              FROM v3_0_localities l \
                                              INNER JOIN v3_0_precincts p ON p.locality_id = l.id AND p.results_id = l.results_id \
                                              INNER JOIN v3_0_precinct_polling_locations ppl ON ppl.precinct_id = p.id AND ppl.results_id = l.results_id \
                                              INNER JOIN v3_0_polling_locations pl ON pl.id = ppl.polling_location_id AND pl.results_id = l.results_id \
                                              INNER JOIN results r ON r.id = l.results_id \
                                              WHERE r.public_id=$1 AND l.id=$2) AS ppl, \
-                                             (SELECT COUNT(pl.*)::int AS count \
+                                             (SELECT COUNT(DISTINCT pl.*)::int AS count \
                                              FROM v3_0_localities l \
                                              INNER JOIN v3_0_precincts p ON p.locality_id = l.id AND p.results_id = l.results_id \
                                              INNER JOIN v3_0_precinct_splits ps ON ps.precinct_id = p.id AND ps.results_id = l.results_id \


### PR DESCRIPTION
Those inner join operations yield four duplicate rows. We found it by
noticing one locality had more polling locations than the entire state.