### PR TITLE
Setup routes for Source & Election error overviews

### DIFF
--- a/pg/services.js
+++ b/pg/services.js
@@ -56,6 +56,8 @@ function registerPostgresServices (app) {
   app.get('/db/5.1/feeds/:feedid/overview/polling_locations/errors', pg51.overviewErrors("PollingLocation"));
   app.get('/db/5.1/feeds/:feedid/overview/localities/errors', pg51.overviewErrors("Locality"));
   app.get('/db/5.1/feeds/:feedid/overview/hours_open/errors', pg51.overviewErrors("HoursOpen"));
+  app.get('/db/5.1/feeds/:feedid/overview/source/errors', pg51.overviewErrors("Source"));
+  app.get('/db/5.1/feeds/:feedid/overview/election/errors', pg51.overviewErrors("Election"));
   app.get('/db/feeds/:feedid/xml/errors/report', csv.xmlTreeValidationErrorReport);
   app.get('/db/feeds/:feedid/xml/error-total-count', pg51.totalErrors);
   app.get('/db/feeds/:feedid/xml/errors/summary', pg51.errorSummary);

--- a/pg/services.js
+++ b/pg/services.js
@@ -50,14 +50,35 @@ function registerPostgresServices (app) {
   ///////// Version 5.1 /////////
   app.get('/db/feeds/:feedid/xml/overview', pg51.feedOverview);
   app.get('/db/feeds/:feedid/xml/overview-summary', pg51.feedOverviewSummaryData);
+
+  // Voting locations
   app.get('/db/5.1/feeds/:feedid/overview/street_segments/errors', pg51.overviewErrors("StreetSegment"));
   app.get('/db/5.1/feeds/:feedid/overview/state/errors', pg51.overviewErrors("State"));
   app.get('/db/5.1/feeds/:feedid/overview/precincts/errors', pg51.overviewErrors("Precinct"));
   app.get('/db/5.1/feeds/:feedid/overview/polling_locations/errors', pg51.overviewErrors("PollingLocation"));
   app.get('/db/5.1/feeds/:feedid/overview/localities/errors', pg51.overviewErrors("Locality"));
   app.get('/db/5.1/feeds/:feedid/overview/hours_open/errors', pg51.overviewErrors("HoursOpen"));
+
+  // Voter Resources
+  app.get('/db/5.1/feeds/:feedid/overview/election_administrations/errors', pg51.overviewErrors("ElectionAdministration"));
+  app.get('/db/5.1/feeds/:feedid/overview/departments/errors', pg51.overviewErrors("Department"));
+  app.get('/db/5.1/feeds/:feedid/overview/voter_services/errors', pg51.overviewErrors("VoterService"));
+
+  // Contests table
+  app.get('/db/5.1/feeds/:feedid/overview/candidate_contests/errors', pg51.overviewErrors("CandidateContest"));
+  app.get('/db/5.1/feeds/:feedid/overview/candidate_selection/errors', pg51.overviewErrors("CandidateSelection"));
+  app.get('/db/5.1/feeds/:feedid/overview/ballot_measure_contests/errors', pg51.overviewErrors("BallotMeasureContest"));
+  app.get('/db/5.1/feeds/:feedid/overview/ballot_selections/errors', pg51.overviewErrors("BallotSelection"));
+  app.get('/db/5.1/feeds/:feedid/overview/retention_contests/errors', pg51.overviewErrors("RetentionContest"));
+  app.get('/db/5.1/feeds/:feedid/overview/party_contests/errors', pg51.overviewErrors("PartyContest"));
+  app.get('/db/5.1/feeds/:feedid/overview/electoral_districts/errors', pg51.overviewErrors("ElectoralDistrict"));
+  app.get('/db/5.1/feeds/:feedid/overview/candidates/errors', pg51.overviewErrors("Candidate"));
+  app.get('/db/5.1/feeds/:feedid/overview/offices/errors', pg51.overviewErrors("Office"));
+
+  // Source & Elections table
   app.get('/db/5.1/feeds/:feedid/overview/source/errors', pg51.overviewErrors("Source"));
   app.get('/db/5.1/feeds/:feedid/overview/election/errors', pg51.overviewErrors("Election"));
+
   app.get('/db/feeds/:feedid/xml/errors/report', csv.xmlTreeValidationErrorReport);
   app.get('/db/feeds/:feedid/xml/error-total-count', pg51.totalErrors);
   app.get('/db/feeds/:feedid/xml/errors/summary', pg51.errorSummary);

--- a/pg/v5_1_queries.js
+++ b/pg/v5_1_queries.js
@@ -38,7 +38,7 @@ var errorResponder = function(query, params) {
 };
 
 var overallErrorQuery = function(scope) {
-    return buildErrorQuery("", "subpath(xtv.path, 2, 1) = '" + scope  +"'");
+    return buildErrorQuery("", "element_type(xtv.path) = '" + scope + "'");
 };
 
 var buildErrorQuery = function(joins, wheres) {
@@ -87,9 +87,9 @@ var getFeedOverviewSummaryData = function(req, res) {
                              overviewTableRow(row, 'Hours Open', 'hours_open', '#/5.1/feeds/' + feedid + '/overview/hours_open/errors')
                            ],
                            voterResources: [
-                             overviewTableRow(row, 'Election Administration', 'election_administration', '#/5.1/feeds/' + feedid + '/overview/election_administeations/errors'),
+                             overviewTableRow(row, 'Election Administration', 'election_administration', '#/5.1/feeds/' + feedid + '/overview/election_administration/errors'),
                              overviewTableRow(row, 'Departments', 'department', '#/5.1/feeds/' + feedid + '/overview/departments/errors'),
-                             overviewTableRow(row, 'Voter Services', 'voter_service', '#/5.1/feeds/' + feedid + '/overview/voter_service/errors'),
+                             overviewTableRow(row, 'Voter Services', 'voter_service', '#/5.1/feeds/' + feedid + '/overview/voter_services/errors'),
                            ],
                            contests: [
                              overviewTableRow(row, 'Candidate Contests', 'candidate_contest', '#/5.1/feeds/' + feedid + '/overview/candidate_contests/errors'),


### PR DESCRIPTION
If you've loaded a feed with bad source or election elements, now you can look at their errors individually. [Pivotal card](https://www.pivotaltracker.com/story/show/127296107)

![screen shot 2016-08-26 at 10 40 58 am](https://cloud.githubusercontent.com/assets/104658/18013046/9cda1d80-6b79-11e6-9229-b1eeac7243eb.png)

![screen shot 2016-08-26 at 10 40 25 am](https://cloud.githubusercontent.com/assets/104658/18013032/874b7888-6b79-11e6-9905-2cbb0b2ba1dd.png)

![screen shot 2016-08-26 at 10 40 49 am](https://cloud.githubusercontent.com/assets/104658/18013061/ad99139c-6b79-11e6-9977-bc903bd40f82.png)


