### PR TITLE
Split error severities in error tables 3.0

### DIFF
--- a/public/app/partials/feed-errors.html
+++ b/public/app/partials/feed-errors.html
@@ -5,21 +5,23 @@
 <div ng-show="errors.length" ng-error-table errors="errors" errors-table-params="errorsTableParams" toggle-error="toggleError" loading="errors"></div>
 
 <section class="data-group">
-  
+
   <span ng-if="!errors" class="is-loading"></span>
-  <table ng-show="errors.length" id="errorsTable" ng-table="errorsTableParams" template-pagination="errorsPagination" class="table-errors">
-    <tr id="error{{$index}}" ng-repeat-start="error in errors">
-      <td width="10%" class="numeric" id="error-count{{$index}}" data-title="'Count'" sortable="'error_count'">
-        <a href="javascript:void(0)" ng-click="toggleError($index)">{{error.count | number}}</a>
+
+  <table ng-show="fatalErrors.length" id="errorsTable" ng-table="errorsTableParams" template-pagination="errorsPagination" class="table-errors">
+    <caption class="fatal-caption">Fatal and Critical Errors &mdash; Must be corrected</caption>
+    <tr id="fatalError{{$index}}" ng-repeat-start="error in fatalErrors">
+      <td width="10%" class="numeric" id="fatalError-count{{$index}}" data-title="'Count'" sortable="'error_count'">
+        <a href="javascript:void(0)" ng-click="toggleError('fatal',$index)">{{error.count | number}}</a>
       </td>
-      <td id="error-type{{$index}}" data-title="'Error Type'" sortable="'severity_text'" class="toggle-td">
-        <a href="javascript:void(0)" ng-click="toggleError($index)">
-          <h3><b class="error-toggle"><span id="errorArrowClosed{{$index}}"><i class="fi-plus"></i></span><span id="errorArrowOpen{{$index}}" hidden><i class="fi-minus"></i></span></b> <strong><i class="fi-alert"></i> {{error.severity | severity}}:</strong> {{error | errorTitle}} [{{error.scope | errorScope}}]</h3>
+      <td id="fatalError-type{{$index}}" data-title="'Error Type'" sortable="'severity_text'" class="toggle-td">
+        <a href="javascript:void(0)" ng-click="toggleError('fatal',$index)">
+          <h3><b class="error-toggle"><span id="fatalErrorArrowClosed{{$index}}"><i class="fi-plus"></i></span><span id="fatalErrorArrowOpen{{$index}}" hidden><i class="fi-minus"></i></span></b> <strong><i class="fi-alert"></i> {{error.severity | severity}}:</strong> {{error | errorTitle}} [{{error.scope | errorScope}}]</h3>
           <p>{{error | errorDescription}}</p>
         </a>
       </td>
     </tr>
-    <tr id="errorDetail{{$index}}" ng-repeat-end hidden style="background-color: #f2f2f2">
+    <tr id="fatalErrorDetail{{$index}}" ng-repeat-end hidden style="background-color: #f2f2f2">
       <td></td>
       <td class="error-item" style="padding: 20px 0px; padding-right: 20px;">
         <div>
@@ -30,6 +32,32 @@
       </td>
     </tr>
   </table>
+
+  <table ng-show="minorErrors.length" id="errorsTable" ng-table="errorsTableParams" template-pagination="errorsPagination" class="table-errors">
+    <caption class="errors-caption">Errors</caption>
+    <tr id="minorError{{$index}}" ng-repeat-start="error in minorErrors">
+      <td width="10%" class="numeric" id="minorError-count{{$index}}" data-title="'Count'" sortable="'error_count'">
+        <a href="javascript:void(0)" ng-click="toggleError('minor',$index)">{{error.count | number}}</a>
+      </td>
+      <td id="minorError-type{{$index}}" data-title="'Error Type'" sortable="'severity_text'" class="toggle-td">
+        <a href="javascript:void(0)" ng-click="toggleError('minor',$index)">
+          <h3><b class="error-toggle"><span id="minorErrorArrowClosed{{$index}}"><i class="fi-plus"></i></span><span id="minorErrorArrowOpen{{$index}}" hidden><i class="fi-minus"></i></span></b> <strong><i class="fi-alert"></i> {{error.severity | severity}}:</strong> {{error | errorTitle}} [{{error.scope | errorScope}}]</h3>
+          <p>{{error | errorDescription}}</p>
+        </a>
+      </td>
+    </tr>
+    <tr id="minorErrorDetail{{$index}}" ng-repeat-end hidden style="background-color: #f2f2f2">
+      <td></td>
+      <td class="error-item" style="padding: 20px 0px; padding-right: 20px;">
+        <div>
+          <small>Sample from the Report:</small>
+          <div ng-if="error" style="background-color: #fbfbfb; border: 1px solid #cecece; padding: 10px"><pre><code>{{error | errorExample}}</code></pre></div>
+          <div ng-if="!error" style="background-color: #fff; padding: 10px">Could not fetch example error.</div>
+        </div>
+      </td>
+    </tr>
+  </table>
+
   <a class="button" href="{{errorReportPath}}" ng-show="errors.length">Download Error Report</a>
   <div ng-show="total_errors > 50000"><small>(Please be patient for large Error Reports to be prepared and downloaded)</small></div>
 

--- a/public/assets/js/app/controllers/5.1/feedErrors51Controller.js
+++ b/public/assets/js/app/controllers/5.1/feedErrors51Controller.js
@@ -1,6 +1,6 @@
 'use strict';
 
-function FeedErrors51Ctrl($scope, $rootScope, $routeParams, $feedDataPaths) {
+function FeedErrors51Ctrl($scope, $rootScope, $routeParams, $errorsService, $feedDataPaths) {
   var publicId = $routeParams.vipfeed;
   $scope.publicId = publicId;
   $scope.pageHeader.title = 'Errors';
@@ -9,33 +9,13 @@ function FeedErrors51Ctrl($scope, $rootScope, $routeParams, $feedDataPaths) {
 
   $scope.errors = null;
 
-  $scope._toggleError = function (prefix, index) {
-    var obj = jQuery("#" + prefix + "ErrorDetail" + index);
-    var arrowClosed = jQuery("#" + prefix + "ErrorArrowClosed" + index);
-    var arrowOpen = jQuery("#" + prefix + "ErrorArrowOpen" + index);
-
-    if (obj.is(":visible")) {
-      obj.hide();
-      arrowClosed.show();
-      arrowOpen.hide();
-    } else {
-      obj.show();
-      arrowClosed.hide();
-      arrowOpen.show();
-    }
-  }
-  $scope.toggleError = $scope._toggleError;
+  $scope.toggleError = $errorsService.toggleError;
 
   $feedDataPaths.getResponse({ path: '/db/feeds/' + publicId + '/xml/errors/summary',
                                scope:  $scope,
                                key: 'errors',
                                errorMessage: 'Cound not retrieve errors' },
                              function (results) {
-                               $scope.fatalErrors = results.filter(function(row) {
-                                 return row.severity === 'fatal' || row.severity === 'critical';
-                               });
-                               $scope.minorErrors = results.filter(function(row) {
-                                 return row.severity === 'warnings' || row.severity === 'errors';
-                               });
+                               $errorsService.splitErrors($scope, results);
                              });
 }

--- a/public/assets/js/app/controllers/5.1/feedErrors51Controller.js
+++ b/public/assets/js/app/controllers/5.1/feedErrors51Controller.js
@@ -14,7 +14,7 @@ function FeedErrors51Ctrl($scope, $rootScope, $routeParams, $errorsService, $fee
   $feedDataPaths.getResponse({ path: '/db/feeds/' + publicId + '/xml/errors/summary',
                                scope:  $scope,
                                key: 'errors',
-                               errorMessage: 'Cound not retrieve errors' },
+                               errorMessage: 'Could not retrieve errors' },
                              function (results) {
                                $errorsService.splitErrors($scope, results);
                              });

--- a/public/assets/js/app/controllers/feedErrorsController.js
+++ b/public/assets/js/app/controllers/feedErrorsController.js
@@ -3,7 +3,7 @@
 // TODO: Need to check these pages, since they rely on some kind of
 // mapping from $location.path() to '/db' routes
 
-function FeedErrorsCtrl($scope, $rootScope, $feedsService, $feedDataPaths, $route, $routeParams, $location, $filter, ngTableParams) {
+function FeedErrorsCtrl($scope, $rootScope, $feedsService, $feedDataPaths, $errorsService, $route, $routeParams, $location, $filter, ngTableParams) {
   // initialize page header variables
   $rootScope.setPageHeader("Errors", $rootScope.getBreadCrumbs(), "feeds", "", null);
 
@@ -19,23 +19,7 @@ function FeedErrorsCtrl($scope, $rootScope, $feedsService, $feedDataPaths, $rout
   // create a unique id for this page based on the breadcrumbs
   $scope.pageId = $rootScope.generatePageId(feedid);
 
-  // Toggle showing/hiding each error's detail panel
-  $scope._toggleError = function (prefix, index) {
-    var obj = jQuery("#" + prefix + "ErrorDetail" + index);
-    var arrowClosed = jQuery("#" + prefix + "ErrorArrowClosed" + index);
-    var arrowOpen = jQuery("#" + prefix + "ErrorArrowOpen" + index);
-
-    if (obj.is(":visible")) {
-      obj.hide();
-      arrowClosed.show();
-      arrowOpen.hide();
-    } else {
-      obj.show();
-      arrowClosed.hide();
-      arrowOpen.show();
-    }
-  }
-  $scope.toggleError = $scope._toggleError;
+  $scope.toggleError = $errorsService.toggleError;
 
   $feedDataPaths.getResponse({ path: '/db' + $location.path(),
                                scope:  $rootScope,
@@ -46,11 +30,6 @@ function FeedErrorsCtrl($scope, $rootScope, $feedsService, $feedDataPaths, $rout
                                $.each(results, function() {
                                  $rootScope.total_errors += parseInt(this.count);
                                });
-                               $scope.fatalErrors = results.filter(function(row) {
-                                 return row.severity === 'fatal' || row.severity === 'critical';
-                               });
-                               $scope.minorErrors = results.filter(function(row) {
-                                 return row.severity === 'warnings' || row.severity === 'errors';
-                               });
+                               $errorsService.splitErrors($scope, results);
                              });
 }

--- a/public/assets/js/app/controllers/feedErrorsController.js
+++ b/public/assets/js/app/controllers/feedErrorsController.js
@@ -20,10 +20,10 @@ function FeedErrorsCtrl($scope, $rootScope, $feedsService, $feedDataPaths, $rout
   $scope.pageId = $rootScope.generatePageId(feedid);
 
   // Toggle showing/hiding each error's detail panel
-  $scope._toggleError = function (index) {
-    var obj = jQuery("#errorDetail" + index);
-    var arrowClosed = jQuery("#errorArrowClosed" + index);
-    var arrowOpen = jQuery("#errorArrowOpen" + index);
+  $scope._toggleError = function (prefix, index) {
+    var obj = jQuery("#" + prefix + "ErrorDetail" + index);
+    var arrowClosed = jQuery("#" + prefix + "ErrorArrowClosed" + index);
+    var arrowOpen = jQuery("#" + prefix + "ErrorArrowOpen" + index);
 
     if (obj.is(":visible")) {
       obj.hide();
@@ -41,10 +41,16 @@ function FeedErrorsCtrl($scope, $rootScope, $feedsService, $feedDataPaths, $rout
                                scope:  $rootScope,
                                key: 'errors',
                                errorMessage: 'Cound not retrieve errors' },
-                             function(result) {
-                              $rootScope.total_errors = 0;
-                              $.each(result, function() {
-                                $rootScope.total_errors += parseInt(this.count);
-                              });
+                             function(results) {
+                               $rootScope.total_errors = 0;
+                               $.each(results, function() {
+                                 $rootScope.total_errors += parseInt(this.count);
+                               });
+                               $scope.fatalErrors = results.filter(function(row) {
+                                 return row.severity === 'fatal' || row.severity === 'critical';
+                               });
+                               $scope.minorErrors = results.filter(function(row) {
+                                 return row.severity === 'warnings' || row.severity === 'errors';
+                               });
                              });
 }

--- a/public/assets/js/app/controllers/feedErrorsController.js
+++ b/public/assets/js/app/controllers/feedErrorsController.js
@@ -24,7 +24,7 @@ function FeedErrorsCtrl($scope, $rootScope, $feedsService, $feedDataPaths, $erro
   $feedDataPaths.getResponse({ path: '/db' + $location.path(),
                                scope:  $rootScope,
                                key: 'errors',
-                               errorMessage: 'Cound not retrieve errors' },
+                               errorMessage: 'Could not retrieve errors' },
                              function(results) {
                                $rootScope.total_errors = 0;
                                $.each(results, function() {

--- a/public/assets/js/app/services/errorsService.js
+++ b/public/assets/js/app/services/errorsService.js
@@ -1,0 +1,36 @@
+'use strict';
+
+vipApp.factory('$errorsService', function () {
+
+  // Split fatal and critical from errors and warnings
+  var splitErrors = function(scope, errors) {
+    scope.fatalErrors = errors.filter(function(error) {
+      return error.severity === 'fatal' || error.severity === 'critical';
+    });
+    scope.minorErrors = errors.filter(function(error) {
+      return error.severity === 'warnings' || error.severity === 'errors';
+    });
+  }
+
+  // Toggle error details on error pages
+  var toggleError = function (prefix, index) {
+    var obj = jQuery("#" + prefix + "ErrorDetail" + index);
+    var arrowClosed = jQuery("#" + prefix + "ErrorArrowClosed" + index);
+    var arrowOpen = jQuery("#" + prefix + "ErrorArrowOpen" + index);
+
+    if (obj.is(":visible")) {
+      obj.hide();
+      arrowClosed.show();
+      arrowOpen.hide();
+    } else {
+      obj.show();
+      arrowClosed.hide();
+      arrowOpen.show();
+    }
+  };
+
+  return {
+    splitErrors: splitErrors,
+    toggleError: toggleError
+  };
+});

--- a/public/index.html
+++ b/public/index.html
@@ -111,6 +111,7 @@
   <script src="assets/js/app/controllers/5.1/feedErrorOverview51Controller.js"></script>
 
   <!-- Shared -->
+  <script src="assets/js/app/services/errorsService.js"></script>
   <script src="assets/js/app/services/feedsService.js"></script>
   <script src="assets/js/app/services/paths.js"></script>
 


### PR DESCRIPTION
Split the error tables for 3.0 feeds into two severity tiers, just like for 5.1 feeds.

Factors out some shared functions, too.

Pivotal story: [129486877](https://www.pivotaltracker.com/story/show/129486877)

<img width="769" alt="screen shot 2016-09-01 at 11 38 27 am" src="https://cloud.githubusercontent.com/assets/3526/18173720/ac7d37e0-7038-11e6-870d-8d1d74738e85.png">
