### PR TITLE
Don't activate error button if there are no errors

### DIFF
--- a/public/app/partials/feed-source.html
+++ b/public/app/partials/feed-source.html
@@ -1,6 +1,14 @@
 <i id="feed-source-content"></i>
 
-<p ng-if="feedSource.error_count !== undefined"><a id="source-errors" class="error-count error-count-{{feedSource.error_count}}" href="{{$location.absUrl()}}/errors">{{feedSource.error_count}} Errors in Source ID: {{feedSource.id}}</a></p>
+<p ng-if="feedSource.error_count !== undefined">
+  <a id="source-errors"
+     class="error-count error-count-{{feedSource.error_count}} "
+     ng-class="{default_pointer: feedSource.error_count == 0}"
+     href="{{feedSource.error_count == 0 ? 'javascript: void(0);' : $location.absUrl() + '/errors'}}">
+    {{feedSource.error_count}} Errors in Source ID: {{feedSource.id}}
+  </a>
+</p>
+
 
 <span ng-if="!feedSource" class="is-loading"></span>
 
@@ -27,8 +35,15 @@
 
 <i id="feed-election-content"></i>
 
-<p ng-if="feedElection.error_count !== undefined"><a id="election-errors" class="error-count error-count-{{feedElection.error_count}}" href="{{$location.absUrl()}}/errors">{{feedElection.error_count}}
-  Errors in Election ID: {{feedElection.id}}</a></p>
+<p ng-if="feedElection.error_count !== undefined">
+  <a id="election-errors"
+     class="error-count error-count-{{feedElection.error_count}}"
+     ng-class="{default_pointer: feedSource.error_count == 0}"
+     href="{{feedElection.error_count == 0 ? 'javascript: void(0);' : $location.absUrl() + '/errors'}}">
+    {{feedElection.error_count}} Errors in Election ID: {{feedElection.id}}
+  </a>
+</p>
+
 
 <span ng-if="!feedElection" class="is-loading"></span>
 


### PR DESCRIPTION
This makes the 'Source & Election' page for 3.0 feeds act like the
overview pages; the pointer changes and the `href` is void.

[Pivotal story](https://www.pivotaltracker.com/story/show/128178757)