### PR TITLE
V5 localities overview

### DIFF
--- a/pg/services.js
+++ b/pg/services.js
@@ -59,6 +59,9 @@ function registerPostgresServices (app) {
   app.get('/db/5.1/feeds/:feedid/overview/localities/errors', pg51.overviewErrors("Locality"));
   app.get('/db/5.1/feeds/:feedid/overview/hours_open/errors', pg51.overviewErrors("HoursOpen"));
 
+  // Localities
+  app.get('/db/5.1/feeds/:feedid/localities', pg51.localityOverview);
+
   // Voter Resources
   app.get('/db/5.1/feeds/:feedid/overview/election_administrations/errors', pg51.overviewErrors("ElectionAdministration"));
   app.get('/db/5.1/feeds/:feedid/overview/departments/errors', pg51.overviewErrors("Department"));

--- a/pg/v5_1_queries.js
+++ b/pg/v5_1_queries.js
@@ -29,7 +29,7 @@ var localityOverviewQuery = "WITH precincts AS (SELECT localities.value AS local
                                                                 ORDER BY parent_with_id, element') \
                                                  AS ct(parent_locality ltree, name text, id text) \
                                                  WHERE id IS NOT NULL) \
-                             SELECT localities.id, localities.name, precincts.count as precincts \
+                             SELECT localities.id as identifier, localities.name, precincts.count as precincts \
                              FROM localities \
                              LEFT JOIN precincts ON localities.id = precincts.locality_id \
                              WHERE localities.id IS NOT NULL \

--- a/public/app/partials/5.1/feed-overview.html
+++ b/public/app/partials/5.1/feed-overview.html
@@ -29,26 +29,26 @@
         </div>
 
         <table ng-show="feedLocalities.length"
-               id="localTable"
+               id="localitiesTable"
                ng-table="localitiesTable"
                template-pagination="localPagination"
                class="associations">
 
           <tr id="locality{{$index}}" ng-repeat="locality in $data">
-            <td id="locality-id{{$index}}" class="id" data-title="'ID'" sortable="'id'">
-              <a href="/#/5.1/feeds/{{vipfeed}}/election/state/localities/{{locality.id}}" data-title-text="ID">
-                <span class="td-text">{{locality.id}}</span>
+            <td id="locality-id{{$index}}" class="id" data-title="'ID'" sortable="'identifier'">
+              <a href="/#/5.1/feeds/{{vipfeed}}/election/state/localities/{{locality.identifier}}" data-title-text="ID">
+                <span class="td-text">{{locality.identifier}}</span>
               </a>
             </td>
 
             <td id="locality-name{{$index}}" class="name" data-title="'Name'" sortable="'name'">
-              <a href="/#/5.1/feeds/{{vipfeed}}/election/state/localities/{{locality.id}}" data-title-text="Name">
+              <a href="/#/5.1/feeds/{{vipfeed}}/election/state/localities/{{locality.identifier}}" data-title-text="Name">
                 <span class="td-text">{{locality.name}}</span>
               </a>
             </td>
 
             <td id="locality-precincts{{$index}}" class="precincts" data-title="'Precincts'" sortable="'precincts'">
-              <a href="/#/feeds/{{vipfeed}}/election/state/localities/{{locality.id}}" data-title-text="Precincts">
+              <a href="/#/feeds/{{vipfeed}}/election/state/localities/{{locality.identifier}}" data-title-text="Precincts">
                 <span class="td-text">{{locality.precincts}}</span>
               </a>
             </td>
@@ -66,7 +66,6 @@
         </script>
       </section>
     </section>
-    <!-- /.data-group -->
 
     <vip-overview-table
        table-data="summaries.voterResources"

--- a/public/app/partials/5.1/feed-overview.html
+++ b/public/app/partials/5.1/feed-overview.html
@@ -10,6 +10,64 @@
        id-prefix="pollingLocation">
     </vip-overview-table>
 
+    <section class="data-group data-module started">
+      <header class="data-group-header">
+        <h2>{{feedLocalities.length}} Localities</h2>
+
+        <span ng-if="!feedLocalities" class="more-detail is-loading"></span>
+        <a class="more-detail"
+           ng-if="feedLocalities"
+           href="{{$location.absUrl()}}/election/state/localities/">
+          More Detail
+        </a>
+      </header>
+
+      <section class="data-group data-module">
+        <div ng-if="!feedLocalities">
+          </br>
+          <span class="is-loading"></span>
+        </div>
+
+        <table ng-show="feedLocalities.length"
+               id="localTable"
+               ng-table="localitiesTable"
+               template-pagination="localPagination"
+               class="associations">
+
+          <tr id="locality{{$index}}" ng-repeat="locality in $data">
+            <td id="locality-id{{$index}}" class="id" data-title="'ID'" sortable="'id'">
+              <a href="/#/5.1/feeds/{{vipfeed}}/election/state/localities/{{locality.id}}" data-title-text="ID">
+                <span class="td-text">{{locality.id}}</span>
+              </a>
+            </td>
+
+            <td id="locality-name{{$index}}" class="name" data-title="'Name'" sortable="'name'">
+              <a href="/#/5.1/feeds/{{vipfeed}}/election/state/localities/{{locality.id}}" data-title-text="Name">
+                <span class="td-text">{{locality.name}}</span>
+              </a>
+            </td>
+
+            <td id="locality-precincts{{$index}}" class="precincts" data-title="'Precincts'" sortable="'precincts'">
+              <a href="/#/feeds/{{vipfeed}}/election/state/localities/{{locality.id}}" data-title-text="Precincts">
+                <span class="td-text">{{locality.precincts}}</span>
+              </a>
+            </td>
+          </tr>
+        </table>
+
+        <script type="text/ng-template" id="localPagination">
+          <ul class="pagination ng-cloak">
+            <li ng-repeat="page in pages"
+                ng-class="{'ng-hide': page.type == 'prev' || page.type == 'next'}">
+              <a id="feedsPage{{$index}}" ng-class="{'is-active': page.number == localitiesTable.page()}"
+                 ng-click="localitiesTable.page(page.number)" href="">{{page.number}}</a>
+            </li>
+          </ul>
+        </script>
+      </section>
+    </section>
+    <!-- /.data-group -->
+
     <vip-overview-table
        table-data="summaries.voterResources"
        table-params="tableParams.voterResources"

--- a/public/assets/js/app/controllers/5.1/feedOverview51Controller.js
+++ b/public/assets/js/app/controllers/5.1/feedOverview51Controller.js
@@ -59,12 +59,12 @@ function FeedOverview51Ctrl($scope, $rootScope, $feedDataPaths, $routeParams,
     $feedDataPaths.getResponse(
       {
         path: '/db/5.1/feeds/' + publicId + '/localities ',
-        scope:  $scope,
+        scope: $scope,
         key: 'feedLocalities',
         errorMessage: 'Cound not retrieve Feed Localities.'
       },
       function(result) {
         $scope.localitiesTable = $rootScope.createTableParams(ngTableParams, $filter, result,
                                                               $appProperties.lowPagination, { name: 'asc' });
-      });1
+      });
 }

--- a/public/assets/js/app/controllers/5.1/feedOverview51Controller.js
+++ b/public/assets/js/app/controllers/5.1/feedOverview51Controller.js
@@ -55,4 +55,16 @@ function FeedOverview51Ctrl($scope, $rootScope, $feedDataPaths, $routeParams,
                        $appProperties.lowPagination,
                        { element_type: 'asc' });
                  });
+
+    $feedDataPaths.getResponse(
+      {
+        path: '/db/5.1/feeds/' + publicId + '/localities ',
+        scope:  $scope,
+        key: 'feedLocalities',
+        errorMessage: 'Cound not retrieve Feed Localities.'
+      },
+      function(result) {
+        $scope.localitiesTable = $rootScope.createTableParams(ngTableParams, $filter, result,
+                                                              $appProperties.lowPagination, { name: 'asc' });
+      });1
 }


### PR DESCRIPTION
We add a paginated table that shows you the _Localities_ of your feed, very much like what you'd find on a v3 feed's overview. One difference is that the locality's `id` isn't being coerced into an integer; this is useful for those hand-generated feeds where IDs look are alphanumeric, e.g., `loc001` where such coercion would yield `NaN`. Another difference is that we're sorting by the name instead of the ID; it seems to be more humane and I like it.

You might notice use of `crosstab` in the query - this is from PostgreSQL's [tablefunc](https://www.postgresql.org/docs/9.4/static/tablefunc.html) extension. We'll need to `create extension tablefunc;` on the DB before this PR gets merged.

[Pivotal story](https://www.pivotaltracker.com/story/show/123274871)