### PR TITLE
Fix error link buttons

### DIFF
--- a/public/app/partials/feed-locality.html
+++ b/public/app/partials/feed-locality.html
@@ -1,6 +1,13 @@
 <i id="feed-locality-content"></i>
 
-<p ng-if="feedLocality !== undefined"><a id="locality-errors" class="error-count error-count-{{feedLocality.error_count}}" href="{{$location.absUrl()}}/errors">{{feedLocality.error_count}} Errors in Locality ID: {{feedLocality.id}}</a></p>
+<p ng-if="feedLocality.error_count !== undefined">
+  <a id="locality-errors"
+     class="error-count error-count-{{feedLocality.error_count}} "
+     ng-class="{default_pointer: feedLocality.error_count == 0}"
+     href="{{feedLocality.error_count == 0 ? 'javascript: void(0);' : $location.absUrl() + '/errors'}}">
+    {{feedLocality.error_count}} Errors in Locality ID: {{feedLocality.id}}
+  </a>
+</p>
 
 <div class="data-module-full">
   <dl class="attributes">

--- a/public/app/partials/feed-source.html
+++ b/public/app/partials/feed-source.html
@@ -1,6 +1,14 @@
 <i id="feed-source-content"></i>
 
-<p ng-if="feedSource.error_count !== undefined"><a id="source-errors" class="error-count error-count-{{feedSource.error_count}}" href="{{$location.absUrl()}}/errors">{{feedSource.error_count}} Errors in Source ID: {{feedSource.id}}</a></p>
+<p ng-if="feedSource.error_count !== undefined">
+  <a id="source-errors"
+     class="error-count error-count-{{feedSource.error_count}} "
+     ng-class="{default_pointer: feedSource.error_count == 0}"
+     href="{{feedSource.error_count == 0 ? 'javascript: void(0);' : $location.absUrl() + '/errors'}}">
+    {{feedSource.error_count}} Errors in Source ID: {{feedSource.id}}
+  </a>
+</p>
+
 
 <span ng-if="!feedSource" class="is-loading"></span>
 
@@ -27,8 +35,15 @@
 
 <i id="feed-election-content"></i>
 
-<p ng-if="feedElection.error_count !== undefined"><a id="election-errors" class="error-count error-count-{{feedElection.error_count}}" href="{{$location.absUrl()}}/errors">{{feedElection.error_count}}
-  Errors in Election ID: {{feedElection.id}}</a></p>
+<p ng-if="feedElection.error_count !== undefined">
+  <a id="election-errors"
+     class="error-count error-count-{{feedElection.error_count}}"
+     ng-class="{default_pointer: feedSource.error_count == 0}"
+     href="{{feedElection.error_count == 0 ? 'javascript: void(0);' : $location.absUrl() + '/errors'}}">
+    {{feedElection.error_count}} Errors in Election ID: {{feedElection.id}}
+  </a>
+</p>
+
 
 <span ng-if="!feedElection" class="is-loading"></span>
 


### PR DESCRIPTION
When there are no errors of a specific type, linking to the errors gives a blank page. This fixes that.

[Bug #1](https://www.pivotaltracker.com/story/show/128178757) and [bug #2](https://www.pivotaltracker.com/story/show/129631863).