### PR TITLE
Show a sample ID to go along with a sample error

### DIFF
--- a/public/assets/js/app/filters.js
+++ b/public/assets/js/app/filters.js
@@ -292,8 +292,9 @@ angular.module('vipFilters', []).
     }}).
   filter('xmlTreeErrorExample', function () {
     return function(error) {
-      var path = error.path;
-      return "path = " + path + " (" + error.error_data + ")";
+      return error.error_data + "\n" +
+             "path = " + error.path + "\n" +
+             "id = " + error.identifier;
     }}).
   filter('errorCompletion', function () {
     return function(overview) {

--- a/public/assets/js/app/filters.js
+++ b/public/assets/js/app/filters.js
@@ -293,8 +293,8 @@ angular.module('vipFilters', []).
   filter('xmlTreeErrorExample', function () {
     return function(error) {
       return error.error_data + "\n" +
-             "path = " + error.path + "\n" +
-             "id = " + error.identifier;
+             "id = " + error.identifier + "\n" +
+             "path = " + error.path;
     }}).
   filter('errorCompletion', function () {
     return function(overview) {


### PR DESCRIPTION
![screen shot 2016-10-11 at 1 30 56 pm](https://cloud.githubusercontent.com/assets/104658/19285407/0ef9141e-8fb7-11e6-8ef7-dc01a1e7ad10.png)

Having only an ID or a path could make it hard to find an element
containing errors. To make it easier, let's show both.