### PR TITLE
Show a locality-based overview for 5.1 feeds

### DIFF
--- a/pg/services.js
+++ b/pg/services.js
@@ -61,6 +61,7 @@ function registerPostgresServices (app) {
 
   // Localities
   app.get('/db/5.1/feeds/:feedid/localities', pg51.localityOverview);
+  app.get('/db/5.1/feeds/:publicId/election/state/localities/:localityId', pg51.localityDetail);
 
   // Voter Resources
   app.get('/db/5.1/feeds/:feedid/overview/election_administrations/errors', pg51.overviewErrors("ElectionAdministration"));

--- a/pg/v5_1_queries.js
+++ b/pg/v5_1_queries.js
@@ -118,7 +118,10 @@ var getLocalityDetail = function(req, res) {
   var localityId = req.params.localityId;
 
   conn.query(function(client) {
-    client.query("SELECT * from locality_stats($1, $2);",
+    client.query("SELECT l.* \
+                  from results r \
+                  left join v5_dashboard.localities l on r.id = l.results_id \
+                  where r.public_id = $1 and l.id = $2 limit 1;",
                  [decodeURIComponent(publicId),
                   decodeURIComponent(localityId)],
                  function(err, result) {

--- a/public/app/partials/5.1/feed-overview.html
+++ b/public/app/partials/5.1/feed-overview.html
@@ -36,19 +36,19 @@
 
           <tr id="locality{{$index}}" ng-repeat="locality in $data">
             <td id="locality-id{{$index}}" class="id" data-title="'ID'" sortable="'identifier'">
-              <a href="/#/5.1/feeds/{{vipfeed}}/election/state/localities/{{locality.identifier}}" data-title-text="ID">
+              <a href="/#/5.1/feeds/{{publicId}}/election/state/localities/{{locality.identifier}}" data-title-text="ID">
                 <span class="td-text">{{locality.identifier}}</span>
               </a>
             </td>
 
             <td id="locality-name{{$index}}" class="name" data-title="'Name'" sortable="'name'">
-              <a href="/#/5.1/feeds/{{vipfeed}}/election/state/localities/{{locality.identifier}}" data-title-text="Name">
+              <a href="/#/5.1/feeds/{{publicId}}/election/state/localities/{{locality.identifier}}" data-title-text="Name">
                 <span class="td-text">{{locality.name}}</span>
               </a>
             </td>
 
             <td id="locality-precincts{{$index}}" class="precincts" data-title="'Precincts'" sortable="'precincts'">
-              <a href="/#/feeds/{{vipfeed}}/election/state/localities/{{locality.identifier}}" data-title-text="Precincts">
+              <a href="/#/5.1/feeds/{{publicId}}/election/state/localities/{{locality.identifier}}" data-title-text="Precincts">
                 <span class="td-text">{{locality.precincts}}</span>
               </a>
             </td>

--- a/public/app/partials/5.1/locality-overview.html
+++ b/public/app/partials/5.1/locality-overview.html
@@ -1,0 +1,39 @@
+<i id="feed-overview-content"></i>
+
+<p ng-if="locality.error_count !== undefined">
+  <a id="locality-errors"
+     class="error-count error-count-{{locality.error_count}} "
+     ng-class="{default_pointer: locality.error_count == 0}"
+     href="{{locality.error_count == 0 ? 'javascript: void(0);' : $location.absUrl() + '/errors'}}">
+    {{locality.error_count}} Errors in Locality ID: {{locality.id}}
+  </a>
+</p>
+
+<div class="data-module-full">
+  <dl class="attributes">
+    <dt class="key">Name:</dt>
+    <dd id="locality-name" class="value">{{locality.name}}</dd>
+    <dt class="key">Type:</dt>
+    <dd id="locality-type" class="value">{{locality.type}}</dd>
+  </dl>
+</div>
+
+<div class="overview-wrap">
+  <section class="data-group data-module started"
+           ng-show="summaries">
+    <vip-overview-table
+       table-data="summaries.pollingLocations"
+       table-params="tableParams.pollingLocations"
+       title="Voting Locations"
+       id-prefix="pollingLocation">
+    </vip-overview-table>
+
+    <vip-overview-table
+       table-data="summaries.voterResources"
+       table-params="tableParams.voterResources"
+       title="Voter Resources"
+       id-prefix="voterResource">
+    </vip-overview-table>
+    </section>
+  </section>
+</div>

--- a/public/assets/js/app/app.js
+++ b/public/assets/js/app/app.js
@@ -79,6 +79,11 @@ vipApp.config(['$routeProvider', '$appProperties', '$httpProvider', '$logProvide
     $routeProvider
       .when('/5.1/feeds/:vipfeed/overview/:type/errors', v5_errors)
 
+    $routeProvider.when('/5.1/feeds/:vipfeed/election/state/localities/:locality', {
+      templateUrl: $appProperties.contextRoot + '/app/partials/5.1/locality-overview.html',
+      controller: 'LocalityOverview51Ctrl'
+    });
+
     // 3.0 feeds
     $routeProvider.when('/feeds/:vipfeed/source', {
       templateUrl: $appProperties.contextRoot + '/app/partials/feed-source.html',

--- a/public/assets/js/app/controllers/5.1/localityOverview51Controller.js
+++ b/public/assets/js/app/controllers/5.1/localityOverview51Controller.js
@@ -1,0 +1,34 @@
+'use strict';
+
+function LocalityOverview51Ctrl($scope, $rootScope, $feedDataPaths, $routeParams,
+                                $appProperties, $filter, ngTableParams) {
+  var publicId = $rootScope.publicId = $routeParams.vipfeed;
+  var localityId = $rootScope.localityId = $routeParams.locality;
+
+  $feedDataPaths
+    .getResponse({path: 'db/5.1/feeds/' + $rootScope.publicId + '/election/state/localities/' + localityId,
+                  scope: $scope,
+                  key: 'summaries',
+                  errorMessage: 'Could not get summary data'},
+                 function (results) {
+                   $scope.locality = results.locality;
+
+                   $scope.tableParams = {};
+
+                   $scope.tableParams.pollingLocations =
+                     $rootScope.createTableParams(
+                       ngTableParams,
+                       $filter,
+                       results.pollingLocations,
+                       $appProperties.lowPagination,
+                       { element_type: 'asc' });
+
+                   $scope.tableParams.voterResources =
+                     $rootScope.createTableParams(
+                       ngTableParams,
+                       $filter,
+                       results.voterResources,
+                       $appProperties.lowPagination,
+                       { element_type: 'asc' });
+                 });
+}

--- a/public/index.html
+++ b/public/index.html
@@ -107,6 +107,7 @@
   <!-- 5.1 -->
   <script src="assets/js/app/controllers/5.1/v5AsideController.js"></script>
   <script src="assets/js/app/controllers/5.1/feedOverview51Controller.js"></script>
+  <script src="assets/js/app/controllers/5.1/localityOverview51Controller.js"></script>
   <script src="assets/js/app/controllers/5.1/feedErrors51Controller.js"></script>
   <script src="assets/js/app/controllers/5.1/feedErrorOverview51Controller.js"></script>
 


### PR DESCRIPTION
This PR is a sibling (and dependent of) a [data-processor PR](https://github.com/votinginfoproject/data-processor/pull/234) and described in [this Pivotal card](https://www.pivotaltracker.com/story/show/123274961).

Here, we give the dashboard a nice view of 5.1 feeds by locality, with the heavy lifting done elsewhere; all the UI needs to do is put the response in an appropriate form for it's template.
