### PR TITLE
Scoped 5.1 error reports

### DIFF
--- a/pg/services.js
+++ b/pg/services.js
@@ -83,6 +83,17 @@ function registerPostgresServices (app) {
   app.get('/db/5.1/feeds/:feedid/overview/election/errors', pg51.overviewErrors("Election"));
 
   app.get('/db/feeds/:feedid/xml/errors/report', csv.xmlTreeValidationErrorReport);
+  app.get('/db/feeds/:feedid/xml/errors/contests/report',
+          csv.scopedXmlTreeValidationErrorReport('Contest',
+                                                 'CandidateContest',
+                                                 'CandidateSelection',
+                                                 'BallotMeasureContest',
+                                                 'BallotSelection',
+                                                 'RetentionContest',
+                                                 'PartyContest',
+                                                 'ElectoralDistrict',
+                                                 'Candidate',
+                                                 'Office'));
   app.get('/db/feeds/:feedid/xml/error-total-count', pg51.totalErrors);
   app.get('/db/feeds/:feedid/xml/errors/summary', pg51.errorSummary);
 

--- a/pg/services.js
+++ b/pg/services.js
@@ -94,6 +94,8 @@ function registerPostgresServices (app) {
                                                  'ElectoralDistrict',
                                                  'Candidate',
                                                  'Office'));
+  app.get('/db/feeds/:feedid/xml/errors/source_election/report',
+          csv.scopedXmlTreeValidationErrorReport('Source', 'Election'));
   app.get('/db/feeds/:feedid/xml/error-total-count', pg51.totalErrors);
   app.get('/db/feeds/:feedid/xml/errors/summary', pg51.errorSummary);
 

--- a/public/app/partials/5.1/errors.html
+++ b/public/app/partials/5.1/errors.html
@@ -61,4 +61,10 @@
     </ul>
   </script>
 
+  <div ng-show="scopedErrorUrl">
+    <a class="button" href="{{scopedErrorUrl}}">
+      Download {{scopedErrorType}} Error Report
+    </a>
+  </div>
+
 </section>

--- a/public/assets/js/app/controllers/5.1/feedErrorOverview51Controller.js
+++ b/public/assets/js/app/controllers/5.1/feedErrorOverview51Controller.js
@@ -24,6 +24,22 @@ function FeedErrorOverview51Ctrl($scope, $rootScope, $routeParams,  $feedDataPat
       arrowOpen.show();
     }
   }
+
+  switch ($routeParams.type) {
+  case "candidate_contests":
+  case "candidate_selections":
+  case "ballot_measure_contests":
+  case "ballot_selections":
+  case "retention_contests":
+  case "party_contests":
+  case "electoral_districts":
+  case "candidates":
+  case "offices":
+    $scope.scopedErrorType = "Contests";
+    $scope.scopedErrorUrl = '/db/feeds/' + publicId + '/xml/errors/contests/report';
+    break;
+  };
+
   $scope.toggleError = $scope._toggleError;
 
   $feedDataPaths.getResponse({ path: '/db' + $location.path(),

--- a/public/assets/js/app/controllers/5.1/feedErrorOverview51Controller.js
+++ b/public/assets/js/app/controllers/5.1/feedErrorOverview51Controller.js
@@ -38,6 +38,11 @@ function FeedErrorOverview51Ctrl($scope, $rootScope, $routeParams,  $feedDataPat
     $scope.scopedErrorType = "Contests";
     $scope.scopedErrorUrl = '/db/feeds/' + publicId + '/xml/errors/contests/report';
     break;
+  case "source":
+  case "election":
+    $scope.scopedErrorType = "Source and Election"
+    $scope.scopedErrorUrl = '/db/feeds/' + publicId + '/xml/errors/source_election/report';
+    break;
   };
 
   $scope.toggleError = $scope._toggleError;


### PR DESCRIPTION
Functions to facilitate generating and providing scoped 5.1 error reports.

For future scopes, you just need to add the report's route to pg/services.js and create new cases in `feedErrorOverview51Controller`.

<img width="763" alt="screen shot 2016-10-25 at 11 16 15 am" src="https://cloud.githubusercontent.com/assets/3526/19692058/7bb2203a-9aa4-11e6-9a8c-95ec7d9aeac4.png">

Pivotal story for contests: [128171689](https://www.pivotaltracker.com/story/show/128171689)
Pivotal story for source and election: [128171487](https://www.pivotaltracker.com/story/show/128171487)
