### PR TITLE
Remove an extra error handler

### DIFF
--- a/pg/conn.js
+++ b/pg/conn.js
@@ -25,10 +25,6 @@ var queryFromPool = function(callback) {
     }
     done();
 });
-
-  pool.on('error', function (err, client) {
-    logger.error('idle client error', err.message, err.stack);
-  });
 }
 
 module.exports = {


### PR DESCRIPTION
If a Postgresql connection is terminated unexpectedly, node-postgres
will already tell use about it. Binding another handler to 'error' trips
an EventEmitter warning; we might or might not be leaking memory.