### PR TITLE
Add election info to results

### DIFF
--- a/pg/queries.js
+++ b/pg/queries.js
@@ -29,7 +29,7 @@ module.exports = {
                  r.public_id, r.start_time, date(r.end_time) AS end_time, \
                  CASE WHEN r.end_time IS NOT NULL \
                       THEN r.end_time - r.start_time END AS duration, \
-                 r.spec_version, r.complete, r.state, r.election_type, r.election_date \
+                 r.spec_version, r.complete, r.election_date, r.election_type, r.state\
           FROM results r \
           ORDER BY r.id DESC \
           LIMIT 20 OFFSET ($1 * 20);",
@@ -38,10 +38,7 @@ module.exports = {
                               THEN r.end_time - r.start_time END AS duration, \
                          r.spec_version, r.complete, r.state, r.election_type, r.election_date \
                   FROM results r \
-                  LEFT JOIN v3_0_sources source3 ON source3.results_id = r.id \
-                  LEFT JOIN xml_tree_values xtv_vip_id ON xtv_vip_id.results_id = r.id \
-                                                    AND xtv_vip_id.simple_path = 'VipObject.Source.VipId' \
-                  WHERE substr(COALESCE(source3.vip_id, xtv_vip_id.value), 0, 3) = ANY ($1) \
+                  WHERE substr(r.vip_id, 0, 3) = ANY ($1) \
                   ORDER BY r.start_time DESC \
                   LIMIT 20 OFFSET ($2 * 20);",
   results: "SELECT * FROM results WHERE public_id=$1",

--- a/pg/queries.js
+++ b/pg/queries.js
@@ -36,21 +36,9 @@ module.exports = {
   feedsForState: "SELECT r.public_id, r.start_time, date(r.end_time) AS end_time, \
                          CASE WHEN r.end_time IS NOT NULL \
                               THEN r.end_time - r.start_time END AS duration, \
-                         r.spec_version, r.complete, COALESCE(s3.name, xtv_state.value) AS state, \
-                         COALESCE(e3.election_type, xtv_type.value) AS election_type, \
-                         CASE WHEN e3.date IS NOT NULL THEN DATE(e3.date) \
-                              WHEN xtv_date.value IS NOT NULL THEN DATE(xtv_date.value) END \
-                              AS election_date \
+                         r.spec_version, r.complete, r.state, r.election_type, r.election_date \
                   FROM results r \
                   LEFT JOIN v3_0_sources source3 ON source3.results_id = r.id \
-                  LEFT JOIN v3_0_states s3 ON s3.results_id = r.id \
-                  LEFT JOIN v3_0_elections e3 ON e3.results_id = r.id \
-                  LEFT JOIN xml_tree_values xtv_state ON xtv_state.results_id = r.id \
-                                                     AND xtv_state.simple_path = 'VipObject.State.Name' \
-                  LEFT JOIN xml_tree_values xtv_type ON xtv_type.results_id = r.id \
-                                                    AND xtv_type.path ~ 'VipObject.*.Election.*.ElectionType.*.Text.0' \
-                  LEFT JOIN xml_tree_values xtv_date ON xtv_date.results_id = r.id \
-                                                    AND xtv_date.simple_path = 'VipObject.Election.Date' \
                   LEFT JOIN xml_tree_values xtv_vip_id ON xtv_vip_id.results_id = r.id \
                                                     AND xtv_vip_id.simple_path = 'VipObject.Source.VipId' \
                   WHERE substr(COALESCE(source3.vip_id, xtv_vip_id.value), 0, 3) = ANY ($1) \

--- a/pg/queries.js
+++ b/pg/queries.js
@@ -29,20 +29,8 @@ module.exports = {
                  r.public_id, r.start_time, date(r.end_time) AS end_time, \
                  CASE WHEN r.end_time IS NOT NULL \
                       THEN r.end_time - r.start_time END AS duration, \
-                 r.spec_version, r.complete, COALESCE(s3.name, xtv_state.value) AS state, \
-                 COALESCE(e3.election_type, xtv_type.value) AS election_type, \
-                 CASE WHEN e3.date IS NOT NULL THEN DATE(e3.date) \
-                      WHEN xtv_date.value IS NOT NULL THEN DATE(xtv_date.value) END \
-                      AS election_date \
+                 r.spec_version, r.complete, r.state, r.election_type, r.election_date \
           FROM results r \
-          LEFT JOIN v3_0_states s3 ON s3.results_id = r.id \
-          LEFT JOIN v3_0_elections e3 ON e3.results_id = r.id \
-          LEFT JOIN xml_tree_values xtv_state ON xtv_state.results_id = r.id \
-                                             AND xtv_state.simple_path = 'VipObject.State.Name' \
-          LEFT JOIN xml_tree_values xtv_type ON xtv_type.results_id = r.id \
-                                            AND xtv_type.path ~ 'VipObject.*.Election.*.ElectionType.*.Text.0' \
-          LEFT JOIN xml_tree_values xtv_date ON xtv_date.results_id = r.id \
-                                            AND xtv_date.simple_path = 'VipObject.Election.Date' \
           ORDER BY r.id DESC \
           LIMIT 20 OFFSET ($1 * 20);",
   feedsForState: "SELECT r.public_id, r.start_time, date(r.end_time) AS end_time, \


### PR DESCRIPTION
This branch for this [pivotal story](https://www.pivotaltracker.com/story/show/135535245) updates the queries used to generate feeds and feeds for state based on saving `election_type`, `state`, `election_date`, and `vip_id` in the `results` table.  Corresponds with [this](https://github.com/votinginfoproject/data-processor/pull/248) PR on data-processor.