### PR TITLE
Polling location count

### DIFF
--- a/pg/v5_1_queries.js
+++ b/pg/v5_1_queries.js
@@ -3,7 +3,8 @@ var queries = require('./queries.js');
 var resp = require('./response.js');
 var util = require('./util.js');
 
-var localityOverviewQuery = "select l.id as identifier, l.name, l.precinct_count as precincts \
+var localityOverviewQuery = "select l.id as identifier, l.name, l.precinct_count as precincts, \
+                                    l.polling_location_count as polling_locations\
                              FROM results r \
                              LEFT JOIN v5_dashboard.localities l ON l.results_id = r.id \
                              WHERE r.public_id = $1 \

--- a/public/app/partials/5.1/feed-overview.html
+++ b/public/app/partials/5.1/feed-overview.html
@@ -49,7 +49,13 @@
 
             <td id="locality-precincts{{$index}}" class="precincts" data-title="'Precincts'" sortable="'precincts'">
               <a href="/#/5.1/feeds/{{publicId}}/election/state/localities/{{locality.identifier}}" data-title-text="Precincts">
-                <span class="td-text">{{locality.precincts}}</span>
+                <span class="td-text">{{locality.precincts | number}}</span>
+              </a>
+            </td>
+
+            <td id="locality-polling-locations{{$index}}" class="polling_locations" data-title="'Polling Locations'" sortable="'polling_locations'">
+              <a href="/#/5.1/feeds/{{publicId}}/election/state/localities/{{locality.identifier}}" data-title-text="Polling Locations">
+                <span class="td-text">{{locality.polling_locations | number}}</span>
               </a>
             </td>
           </tr>


### PR DESCRIPTION
For [this story](https://www.pivotaltracker.com/story/show/136989057) I changed the query that populates the localities table on the feed overview page to also grab the polling_location_count.  I added `| number` so it would show `0` instead of nothing when there are `0` polling_locations for a locality.  I also noticed for `precincts` the same thing was happening so I added the filter there as well, though arguably that could/should be handled separately and might need to be added elsewhere.