### PR TITLE
Polling Location address errors report

### DIFF
--- a/pg/csv.js
+++ b/pg/csv.js
@@ -182,6 +182,39 @@ var xmlTreeLocalityErrorReport = function(req, res) {
 
 }
 
+var pollingLocationAddressReport = function(req, res) {
+  var header = ["Locality Name", "Precinct Name", "Address Locaiton Name", "Address Line 1", "Address Line 2", "Address Line 3", "Address City", "Address State",  "Address Zip", "Polling Location Id"];
+  var feedid = decodeURIComponent(req.params.feedid);
+  conn.query(function(client) {
+
+    res.header("Content-Disposition", "attachment; filename=" + csvFilename(feedid));
+    res.setHeader('Content-type', 'text/csv');
+    res.charset = 'UTF-8';
+
+    res.write(makeCSVRow(header));
+
+    var query = client.query('select * from v3_dashboard.polling_location_readable_report($1)', [feedid]);
+
+    query.on("row", function(row, result) {
+      res.write(makeCSVRow([row.locality_name,
+                            row.precinct_name,
+                            row.address_location_name,
+                            row.address_line1,
+                            row.address_line2,
+                            row.address_line3,
+                            row.address_city,
+                            row.address_state,
+                            row.address_zip,
+                            row.polling_location_id]));
+    });
+
+    query.on("end", function(result) {
+      res.end();
+    });
+  });
+
+}
+
 module.exports = {
   xmlTreeLocalityErrorReport: xmlTreeLocalityErrorReport,
   errorReport: errorReport,
@@ -190,5 +223,6 @@ module.exports = {
     return errorReport("", "v.scope = '" + scope + "'", [], scope);
   },
   xmlTreeValidationErrorReport: xmlTreeValidationErrorReport,
-  scopedXmlTreeValidationErrorReport: scopedXmlTreeValidationErrorReport
+  scopedXmlTreeValidationErrorReport: scopedXmlTreeValidationErrorReport,
+  pollingLocationAddressReport: pollingLocationAddressReport
 }

--- a/pg/csv.js
+++ b/pg/csv.js
@@ -183,7 +183,7 @@ var xmlTreeLocalityErrorReport = function(req, res) {
 }
 
 var pollingLocationAddressReport = function(req, res) {
-  var header = ["Locality Name", "Precinct Name", "Address Locaiton Name", "Address Line 1", "Address Line 2", "Address Line 3", "Address City", "Address State",  "Address Zip", "Polling Location Id"];
+  var header = ["Locality Name", "Precinct Name", "Address Location Name", "Address Line 1", "Address Line 2", "Address Line 3", "Address City", "Address State",  "Address Zip", "Polling Location Id"];
   var feedid = decodeURIComponent(req.params.feedid);
   conn.query(function(client) {
 

--- a/pg/services.js
+++ b/pg/services.js
@@ -41,6 +41,7 @@ function registerPostgresServices (app) {
   app.get('/db/feeds/:feedid/overview/electoraldistricts/errors/report', csv.scopedErrorReport("electoral-districts"));
   app.get('/db/feeds/:feedid/overview/localities/errors/report', csv.scopedErrorReport("localities"));
   app.get('/db/feeds/:feedid/overview/pollinglocations/errors/report', csv.scopedErrorReport("polling-locations"));
+  app.get('/db/feeds/:feedid/overview/pollinglocations/errors/address/report', csv.pollingLocationAddressReport);
   app.get('/db/feeds/:feedid/overview/precincts/errors/report', csv.scopedErrorReport("precincts"));
   app.get('/db/feeds/:feedid/overview/precinctsplits/errors/report', csv.scopedErrorReport("precinct-splits"));
   app.get('/db/feeds/:feedid/overview/referenda/errors/report', csv.scopedErrorReport("referendums"));

--- a/public/app/partials/feed-errors.html
+++ b/public/app/partials/feed-errors.html
@@ -60,6 +60,7 @@
 
   <a class="button" href="{{errorReportPath}}" ng-show="errors.length">Download Error Report</a>
   <div ng-show="total_errors > 50000"><small>(Please be patient for large Error Reports to be prepared and downloaded)</small></div>
+  <a class="button" href="{{pollingLocationReportPath}}" ng-show="{{pageId == 'feeds-overview-pollinglocations-errors-content'}}">Download Polling Location Address Error Report</a>
 
   <script type="text/ng-template" id="errorsPagination">
     <ul class="pagination ng-cloak">

--- a/public/assets/js/app/controllers/feedErrorsController.js
+++ b/public/assets/js/app/controllers/feedErrorsController.js
@@ -8,6 +8,7 @@ function FeedErrorsCtrl($scope, $rootScope, $feedsService, $feedDataPaths, $erro
   $rootScope.setPageHeader("Errors", $rootScope.getBreadCrumbs(), "feeds", "", null);
 
   $rootScope.errorReportPath = "/db" + $location.path() + "/report";
+  $rootScope.pollingLocationReportPath = "/db" + $location.path() + "/address/report";
 
   // clear previous errors (so they don't weirdly show up on the page)
   $rootScope.errors = null;


### PR DESCRIPTION
For [this story](https://www.pivotaltracker.com/story/show/137023653) and related to this [data-processor PR](https://github.com/votinginfoproject/data-processor/pull/253)  there is now an additional report to download on the polling location errors overview page.  It generates `locality name`, `precinct name`, and `address`-related fields for all polling locations with errors.  Accomplishing this required adding a new report to `csv.js`, creating a new url to access that report in `pg/services.js` and adding to the `feedErrorsController` and `feed-errors` template to configure the button to be displayed.