### PR TITLE
Add vit staging tool page

### DIFF
--- a/public/app/partials/5.1/vit.html
+++ b/public/app/partials/5.1/vit.html
@@ -1,0 +1,9 @@
+<i id="feed-vit"></i>
+
+<section class="data-group data-module">
+  <h2>VIP Staging Tool</h2>
+
+  <p>After first version of a feed for a given election has been submitted, and all fatal errors have been resolved, the VIP Team will configure it for ingestion into the Google Civic API. No data will be public, but you can review the data prior to publication using the tool below.</p>
+ 
+  <p>Note: Data may not be available immediately after submission to the VIP dashboard.</p>
+</section>

--- a/public/app/partials/feed-vit.html
+++ b/public/app/partials/feed-vit.html
@@ -1,0 +1,9 @@
+<i id="feed-vit"></i>
+
+<section class="data-group data-module">
+  <h2>VIP Staging Tool</h2>
+
+  <p>After first version of a feed for a given election has been submitted, and all fatal errors have been resolved, the VIP Team will configure it for ingestion into the Google Civic API. No data will be public, but you can review the data prior to publication using the tool below.</p>
+ 
+  <p>Note: Data may not be available immediately after submission to the VIP dashboard.</p>
+</section>

--- a/public/assets/js/app/app.js
+++ b/public/assets/js/app/app.js
@@ -95,6 +95,12 @@ vipApp.config(['$routeProvider', '$appProperties', '$httpProvider', '$logProvide
       controller: 'LocalityOverview51Ctrl'
     });
 
+    $routeProvider.when('/5.1/feeds/:vipfeed/vit', {
+      templateUrl: $appProperties.contextRoot + '/app/partials/5.1/vit.html',
+      controller: 'FeedVITCtrl' //Uses same controller as 3.0 feeds
+    });
+
+
     // 3.0 feeds
     $routeProvider.when('/feeds/:vipfeed/source', {
       templateUrl: $appProperties.contextRoot + '/app/partials/feed-source.html',

--- a/public/assets/js/app/app.js
+++ b/public/assets/js/app/app.js
@@ -161,6 +161,11 @@ vipApp.config(['$routeProvider', '$appProperties', '$httpProvider', '$logProvide
       controller: 'FeedLocalityCtrl'
     });
 
+    $routeProvider.when('/feeds/:vipfeed/vit', {
+      templateUrl: $appProperties.contextRoot + '/app/partials/feed-vit.html',
+      controller: 'FeedVITCtrl'
+    });
+
     // for all election administration pages
     $routeProvider
       .when('/feeds/:vipfeed/election/state/electionadministration', { templateUrl: $appProperties.contextRoot + '/app/partials/feed-electionadministration.html', controller: 'FeedElectionAdministrationCtrl' })

--- a/public/assets/js/app/controllers/feedVITController.js
+++ b/public/assets/js/app/controllers/feedVITController.js
@@ -1,0 +1,9 @@
+'use strict';
+/*
+ * VIT Staging Controller
+ *
+ */
+function FeedVITCtrl($scope, $rootScope, $homeService, $routeParams) {
+  // initialize page header variables
+  $rootScope.setPageHeader("Voter Information Tool Staging", $rootScope.getBreadCrumbs(), "feeds", "", null);
+}


### PR DESCRIPTION
Adds the VIT staging landing pages for both 3.0 and 5.1 feeds, as per [this Pivotal Card](https://www.pivotaltracker.com/story/show/141707995).

Sorry about the slightly out-of-order merging in of master at the end rather than the start, but there were no overlaps so seemed innocuous.