### PR TITLE
fix parameter name for locality error report request

### DIFF
--- a/pg/csv.js
+++ b/pg/csv.js
@@ -153,7 +153,7 @@ var xmlTreeValidationErrorReport = function(req, res) {
 
 var xmlTreeLocalityErrorReport = function(req, res) {
   var header = ["Feed", "Severity", "Scope", "Path", "ID", "Error Type", "Error Data"];
-  var feedid = decodeURIComponent(req.params.publicId);
+  var feedid = decodeURIComponent(req.params.feedid);
   var localityid = decodeURIComponent(req.params.localityId)
   conn.query(function(client) {
 


### PR DESCRIPTION
While working on another task I realized the locality error report was broken--it was using the wrong variable name to extract the `:feedid` from the url.  This fixes it. [Bug](https://www.pivotaltracker.com/story/show/144616189)