### PR TITLE
Kill xml tree values refs

### DIFF
--- a/notifications/sender.js
+++ b/notifications/sender.js
@@ -92,11 +92,9 @@ module.exports = {
                       JSON.stringify(message));
     }
 
-    var vip_id_query = "SELECT v3.vip_id AS v3_vip_id, v5.value AS v5_vip_id \
+    var vip_id_query = "SELECT v3.vip_id AS v3_vip_id, r.vip_id \
                         FROM results r \
                         LEFT JOIN v3_0_sources v3 ON r.id = v3.results_id \
-                        LEFT JOIN xml_tree_values v5 ON r.id = v5.results_id \
-                              AND v5.simple_path = 'VipObject.Source.VipId' \
                         WHERE r.public_id = $1";
 
     var publicId = message[":public-id"];

--- a/pg/csv.js
+++ b/pg/csv.js
@@ -71,20 +71,16 @@ var errorReport = function(innerJoins, where, params, scope) {
 }
 
 var xmlTreeValidationQuery =
-"SELECT v.severity, v.scope, v.path, x.value AS identifier, \
+"SELECT v.severity, v.scope, v.path, v.value AS identifier, \
         v.error_type, v.error_data \
  FROM xml_tree_validations v \
- LEFT JOIN xml_tree_values x \
-        ON x.path = subpath(v.path,0,4) || 'id' AND x.results_id = v.results_id \
  INNER JOIN results r ON r.id = v.results_id \
  WHERE r.public_id = $1";
 
 var scopedXmlTreeValidationQuery = function(elementTypes) {
-  return "SELECT v.severity, v.scope, v.path, x.value AS identifier, \
+  return "SELECT v.severity, v.scope, v.path, v.value AS identifier, \
         v.error_type, v.error_data \
  FROM xml_tree_validations v \
- LEFT JOIN xml_tree_values x \
-        ON x.path = subpath(v.path,0,4) || 'id' AND x.results_id = v.results_id \
  INNER JOIN results r ON r.id = v.results_id \
  WHERE r.public_id = $1 AND v.path ~ 'VipObject.0." + elementTypes.join("|") + ".*'";
 }

--- a/pg/csv.js
+++ b/pg/csv.js
@@ -71,14 +71,14 @@ var errorReport = function(innerJoins, where, params, scope) {
 }
 
 var xmlTreeValidationQuery =
-"SELECT v.severity, v.scope, v.path, v.value AS identifier, \
+"SELECT v.severity, v.scope, v.path, v.parent_element_id AS identifier, \
         v.error_type, v.error_data \
  FROM xml_tree_validations v \
  INNER JOIN results r ON r.id = v.results_id \
  WHERE r.public_id = $1";
 
 var scopedXmlTreeValidationQuery = function(elementTypes) {
-  return "SELECT v.severity, v.scope, v.path, v.value AS identifier, \
+  return "SELECT v.severity, v.scope, v.path, v.parent_element_id AS identifier, \
         v.error_type, v.error_data \
  FROM xml_tree_validations v \
  INNER JOIN results r ON r.id = v.results_id \

--- a/pg/v5_1_queries.js
+++ b/pg/v5_1_queries.js
@@ -10,17 +10,8 @@ var localityOverviewQuery = "select l.id as identifier, l.name, l.precinct_count
                              WHERE r.public_id = $1 \
                              ORDER BY l.name;";
 
-var overviewQuery = "select r.id, \
-                     xtv_state.value as state_name, \
-                     xtv_type.value as election_type, \
-                     xtv_date.value as election_date \
+var overviewQuery = "select r.id, r.state state_name, r.election_type, r.election_date \
                      from results r \
-                     left join xml_tree_values xtv_state on xtv_state.results_id = r.id \
-                                           and xtv_state.simple_path = 'VipObject.State.Name' \
-                     left join xml_tree_values xtv_type on xtv_type.results_id = r.id \
-                                           and xtv_type.path ~ 'VipObject.*.Election.*.ElectionType.*.Text.0' \
-                     left join xml_tree_values xtv_date on xtv_date.results_id = r.id \
-                                           and xtv_date.simple_path = 'VipObject.Election.Date' \
                      where r.public_id = $1;";
 
 var totalErrorsQuery = "select (select count(v.*) \

--- a/pg/v5_1_queries.js
+++ b/pg/v5_1_queries.js
@@ -25,23 +25,19 @@ var totalErrorsQuery = "select (select count(v.*) \
                         from results r where r.public_id = $1;"
 
 var errorSummary =
-    "WITH errors AS (SELECT DISTINCT ON (v.severity, v.scope, v.error_type) \
-                  v.results_id, \
-                  COUNT(1) AS count, \
-                  v.severity, \
-                  v.scope, \
-                  v.error_type, \
-                  (array_agg(v.path))[1] AS path, \
-                  (array_agg(v.error_data))[1] AS error_data \
-                FROM results r \
-                LEFT JOIN xml_tree_validations v ON v.results_id = r.id \
-                WHERE r.public_id = $1 \
-                GROUP BY v.severity, v.scope, v.error_type, v.results_id) \
-     SELECT errors.*, x.value AS identifier \
-     FROM errors \
-     LEFT JOIN xml_tree_values x  \
-            ON x.path = subpath(errors.path,0,4) || 'id' \
-     AND x.results_id = errors.results_id;";
+    "SELECT DISTINCT ON (v.severity, v.scope, v.error_type) \
+                   v.results_id, \
+                   COUNT(1) AS count, \
+                   v.severity, \
+                   v.scope, \
+                   v.error_type, \
+                   (array_agg(v.path))[1] AS path, \
+                   (array_agg(v.error_data))[1] AS error_data, \
+                   v.parent_element_id as identifier \
+                 FROM results r \
+                 LEFT JOIN xml_tree_validations v ON v.results_id = r.id \
+                 WHERE r.public_id = $1 \
+                 GROUP BY v.severity, v.scope, v.error_type, v.results_id, v.parent_element_id;";
 
 var errorResponder = function(query, params) {
   return util.simpleQueryResponder(query, util.paramExtractor(params));


### PR DESCRIPTION
This PR is a companion to [this data-processor PR](https://github.com/votinginfoproject/data-processor/pull/265) and [this research card](https://www.pivotaltracker.com/story/show/139318429).  It's purpose is to remove references to `xml_tree_values` that happen after processing is complete so that we can decrease the size of the database by dropping the raw data after processing is complete.  Some of the changes were made to use the new value `parent_element_id` that was added `xml_tree_validations` and others were replaced where data can come from tables other than `xml_tree_values` and had simply not yet been rewritten to do so.