### PR TITLE
Email results link to group when testing is complete

### DIFF
--- a/data-testing/aws.js
+++ b/data-testing/aws.js
@@ -38,7 +38,8 @@ module.exports = {
           Body: fileStream
         }, function (err) {
           if (err) {
-            throw err; } else {
+            throw err;
+          } else {
             queue.submitAddressFile(bucketName, fileName, groupName);
           }
         });

--- a/data-testing/aws.js
+++ b/data-testing/aws.js
@@ -26,15 +26,20 @@ module.exports = {
       });
       fileStream.on('open', function () {
         var s3 = new AWS.S3();
-        var bucketName = 'address-testing/' + authorization.stateGroupNames(req.user)[0] + '/input';
+        var groupName = authorization.stateGroupNames(req.user)[0];
+        if (groupName === undefined) {
+          groupName = "undefined"
+        };
+        var bucketName = 'address-testing/' + groupName + '/input';
         var fileName = files.file.originalFilename;
         s3.putObject({
           Bucket: bucketName,
           Key: fileName,
           Body: fileStream
         }, function (err) {
-          if (err) { throw err; } else {
-            queue.submitAddressFile(bucketName, fileName);
+          if (err) {
+            throw err; } else {
+            queue.submitAddressFile(bucketName, fileName, groupName);
           }
         });
       });

--- a/data-testing/content.js
+++ b/data-testing/content.js
@@ -2,8 +2,8 @@ var baseUrl = process.env.BASE_URI || "localdocker:4000";
 
 module.exports = {
   testingComplete: function(message) {
-    return "<p> Your batch address test has completed.  Go <a href='https://" + message['url'] + "'>here</a> to download \
-            your results.</p> <p>It will be available for 72 hours.</p>";
+    return "<p> Your batch address test has completed.  Go <a href='" + message['url'] + "'>here</a> to download " +
+    "your results.</p> <p>It will be available for 72 hours.</p>";
   },
   errorDuringTesting: function(message) {
     return 'It looks like a batch address failed during processing. Here\'s the information we got: \

--- a/data-testing/content.js
+++ b/data-testing/content.js
@@ -1,0 +1,12 @@
+var baseUrl = process.env.BASE_URI || "localdocker:4000";
+
+module.exports = {
+  testingComplete: function(message) {
+    return "<p> Your batch address test has completed.  Go <a href='https://" + message['url'] + "'>here</a> to download \
+            your results.</p> <p>It will be available for 72 hours.</p>";
+  },
+  errorDuringTesting: function(message) {
+    return 'It looks like a batch address failed during processing. Here\'s the information we got: \
+            \nMessage we got: ' + JSON.stringify(message);
+  }
+}

--- a/data-testing/queue.js
+++ b/data-testing/queue.js
@@ -11,7 +11,9 @@ var logAndThrowPossibleError = function(err) {
   }
 }
 
-var generateUUID = function() {
+var generatePseudoRandomRequestID = function() {
+  // function used to generate pseudo-random numbers to be used as transactionIds
+  // adapted from here: https://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript#2117523
   return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
     var r = Math.random()*16|0, v = c == 'x' ? r : (r&0x3|0x8);
     return v.toString(16);
@@ -19,7 +21,7 @@ var generateUUID = function() {
 };
 
 var submitAddressFile = function(bucketName, fileName, groupName) {
-  var transactionId = generateUUID();
+  var transactionId = generatePseudoRandomRequestID();
   console.log(transactionId);
   if (sendAddressFileMessage != null) {
     sendAddressFileMessage(new Buffer(edn.encode({"bucketName": bucketName,

--- a/data-testing/queue.js
+++ b/data-testing/queue.js
@@ -1,5 +1,6 @@
 var logger = (require('../logging/vip-winston')).Logger;
 var edn = require("jsedn");
+var sender = require ("./sender");
 
 var sendAddressFileMessage = null;
 
@@ -34,6 +35,7 @@ var setupAddressFileRequest = function(ch) {
 var processAddressFileResponse = function(msg) {
   // TODO: replace with actual processing later
   logger.info(msg.content.toString());
+  sender.sendNotifications(msg);
 };
 
 var setupAddressFileResponse = function(ch) {

--- a/data-testing/queue.js
+++ b/data-testing/queue.js
@@ -11,10 +11,21 @@ var logAndThrowPossibleError = function(err) {
   }
 }
 
-// TODO: replace contents with actual parameters, convert to JSON string
-var submitAddressFile = function(bucketName, fileName) {
+var generateUUID = function() {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+    var r = Math.random()*16|0, v = c == 'x' ? r : (r&0x3|0x8);
+    return v.toString(16);
+  });
+};
+
+var submitAddressFile = function(bucketName, fileName, groupName) {
+  var transactionId = generateUUID();
+  console.log(transactionId);
   if (sendAddressFileMessage != null) {
-    sendAddressFileMessage(new Buffer(edn.encode({"bucketName": bucketName, "fileName": fileName})));
+    sendAddressFileMessage(new Buffer(edn.encode({"bucketName": bucketName,
+                                                  "fileName": fileName,
+                                                  "groupName": groupName,
+                                                  "transactionId": transactionId})));
   } else {
     throw "Not connected to message queue for address file processing."
   }
@@ -33,9 +44,9 @@ var setupAddressFileRequest = function(ch) {
 };
 
 var processAddressFileResponse = function(msg) {
-  // TODO: replace with actual processing later
-  logger.info(msg.content.toString());
-  sender.sendNotifications(msg);
+  var message = edn.toJS(edn.parse(msg.content.toString()));
+  logger.info(message);
+  sender.sendNotifications(message);
 };
 
 var setupAddressFileResponse = function(ch) {

--- a/data-testing/sender.js
+++ b/data-testing/sender.js
@@ -1,0 +1,90 @@
+var config = require('../config');
+var logger = (require('../logging/vip-winston')).Logger;
+var nodemailer = require('nodemailer');
+var sesTransport = require('nodemailer-ses-transport');
+var messageContent = require('./content');
+var stormpathREST = require('stormpath');
+
+if(config.auth.uselocalauth()) {
+  logger.info('Stormpath credentials are not set!');
+} else {
+  var stormpathRESTApiKey = new stormpathREST.ApiKey(config.auth.apiKey, config.auth.apiKeySecret);
+  var stormpathRESTClient = new stormpathREST.Client({ apiKey: stormpathRESTApiKey });
+}
+
+var transporter = nodemailer.createTransport(sesTransport({
+  accessKeyId: config.aws.accessKey,
+  secretAccessKey: config.aws.secretKey,
+  rateLimit: config.email.rateLimit,
+  region: config.aws.region
+}));
+
+var messageOptions = {
+  testingComplete: function(message, recipient) {
+    return {
+      from: config.email.fromAddress,
+      to: recipient.email,
+      subject: "A batch address test has completed",
+      html: messageContent.testingComplete(message)
+    }
+  },
+  errorDuringTesting: function(message, recipient) {
+    return {
+      from: config.email.fromAddress,
+      to: recipient.email,
+      subject: "A batch address test has failed",
+      html: messageContent.errorDuringTesting(message)
+    }
+  },
+};
+
+var sendMessage = function(messageContent) {
+//   transporter.sendMail(messageContent, function(error, info) {
+//     if (error) {
+//       logger.info('Sending error: ' + error);
+//       logger.info('Message: ' + JSON.stringify(messageContent));
+//     }
+//   });
+  logger.info("fake sending something!" + messageContent.toString())
+};
+
+var notifyGroup = function(message, groupName, contentFn) {
+  if (message["adminEmail"] == true) { groupName = config.email.adminGroup; }
+  stormpathRESTClient.getGroups({ name: groupName }, function(err, groups) {
+    if (err) throw err;
+    groups.each(function(group) {
+
+      group.getAccounts(function(err, accounts) {
+        if (err) throw err;
+
+        for( i = 0; i < accounts.items.length; i++ ) {
+          var recipient = accounts.items[i];
+          var messageContent = contentFn(message, recipient);
+
+          sendMessage(messageContent);
+        }
+      });
+    });
+  });
+};
+
+module.exports = {
+  sendNotifications: function(message) {
+    if(config.auth.uselocalauth()) {
+      logger.warning('A message was trying to be sent but cannot be Stormpath \
+                      credentials are not set! Message: ' + message);
+    } else {
+      var messageType;
+      if (message['status'] == "ok") {
+        messageType = messageOptions.testingComplete;
+      } else {
+        messageType = messageOptions.errorDuringTesting;
+      };
+      if (message['group']) {
+            notifyGroup(message, message['group'], messageType);
+      } else {
+            notifyGroup(message, config.email.adminGroup, messageType);
+      }
+    }
+  }
+};

--- a/data-testing/sender.js
+++ b/data-testing/sender.js
@@ -45,7 +45,6 @@ var sendMessage = function(messageContent) {
       logger.info('Message: ' + JSON.stringify(messageContent));
     }
   });
-  logger.info("fake sending something!" + messageContent.toString())
 };
 
 var notifyGroup = function(message, groupName, contentFn) {


### PR DESCRIPTION
For [this card](https://www.pivotaltracker.com/story/show/145070373) we added functionality to listen for messages on `batch-address.file.complete` to send an email to the user with a link they can use to download their results file.  Much of the functionality is copied from the `notifications` directory in the project but has been changed to suit the needs here, specifically [`content.js`](https://github.com/votinginfoproject/Metis/compare/testing-tools...email-results-link?diff=unified&expand=1&name=email-results-link#diff-37b5e3f4d9f6de618978d1b03115ffb3) and [`sender.js`](https://github.com/votinginfoproject/Metis/compare/testing-tools...email-results-link?diff=unified&expand=1&name=email-results-link#diff-4f6db4b60486b7666b5d423c46d3c5ef).