### PR TITLE
Show latest results file

### DIFF
--- a/data-testing/aws.js
+++ b/data-testing/aws.js
@@ -44,4 +44,39 @@ module.exports = {
     return;
 
   },
-}
+  getLatestResultsFile: function(req, res){
+    var s3 = new AWS.S3();
+    var groupName = authorization.stateGroupNames(req.user)[0];
+    if (groupName === undefined) {
+      groupName = "undefined";
+    }
+    var bucketName = 'address-testing';
+    var fileName  = groupName + "/output/results.csv"
+
+    var params = {
+      Bucket: bucketName,
+      MaxKeys: 1,
+      Prefix: fileName
+    };
+    s3.listObjects(params, function(err, data) {
+      if (err) {
+        console.log(err, err.stack);
+        res.writeHead(500, {'content-type': 'text/plain'});
+        res.end();
+      } else {
+        console.log(data);
+        if (data["Contents"] != []) {
+          var params = {Bucket: bucketName, Key: fileName};
+          var url = s3.getSignedUrl('getObject', params);
+          console.log('The URL is', url);
+          res.writeHead(200, {'content-type': 'text/plain'});
+          res.write(url);
+          res.end();
+        } else {
+          res.writeHead(404, {'content-type': 'text/plain'});
+          res.end();
+        }
+      }
+    });
+  }
+};

--- a/data-testing/aws.js
+++ b/data-testing/aws.js
@@ -64,11 +64,9 @@ module.exports = {
         res.writeHead(500, {'content-type': 'text/plain'});
         res.end();
       } else {
-        console.log(data);
         if (data["Contents"] != []) {
           var params = {Bucket: bucketName, Key: fileName};
           var url = s3.getSignedUrl('getObject', params);
-          console.log('The URL is', url);
           res.writeHead(200, {'content-type': 'text/plain'});
           res.write(url);
           res.end();

--- a/data-testing/services.js
+++ b/data-testing/services.js
@@ -2,6 +2,7 @@ var aws = require("./aws.js");
 
 function registerDataVerificationServices (app) {
   app.post('/testing/upload', aws.uploadAddressFile);
+  app.get('/testing/latest-results-file', aws.getLatestResultsFile);
 }
 
 exports.registerDataVerificationServices = registerDataVerificationServices;

--- a/public/app/partials/testing/addresses.html
+++ b/public/app/partials/testing/addresses.html
@@ -20,7 +20,7 @@
   </form>
 
   <div ng-if="latestResultsFileUrl">
-    <p>Download your lastest results <a href="{{latestResultsFileUrl}}">here</a>.</p>
+    <p>Download your latest results <a href="{{latestResultsFileUrl}}">here</a>.</p>
   </div>
 
 </section>

--- a/public/app/partials/testing/addresses.html
+++ b/public/app/partials/testing/addresses.html
@@ -19,4 +19,8 @@
     <div class="button" ngf-select="upload($file)">Upload Test Addresses</div>
   </form>
 
+  <div ng-if="latestResultsFileUrl">
+    <p>Download your lastest results <a href="{{latestResultsFileUrl}}">here</a>.</p>
+  </div>
+
 </section>

--- a/public/assets/js/app/controllers/testing/addressesController.js
+++ b/public/assets/js/app/controllers/testing/addressesController.js
@@ -3,7 +3,7 @@
  * Batch Addresses Controller
  *
  */
-function AddressesCtrl($scope, $rootScope, Upload) {
+function AddressesCtrl($scope, $rootScope, Upload, $configService) {
   var breadcrumbs = null;
   // initialize page header variables
   $rootScope.setPageHeader("Batch Check Test Addresses", breadcrumbs, "testing", "", null);
@@ -22,5 +22,6 @@ function AddressesCtrl($scope, $rootScope, Upload) {
         });
     };
 
-
+    $configService.getResponse({ path: '/testing/latest-results-file'},
+                               function(result) { $scope.latestResultsFileUrl = result; });
 };


### PR DESCRIPTION
For [this card](https://www.pivotaltracker.com/story/show/144616523) we added another endpoint to the node app to check for a results file in a given user's group's output bucket (i.e. if a user in the Alaska group has submitted a file we can expected their results file to be in `address-testing/02/output/results.csv` so when they visit that page we're going to check for that file and display a link if it exists).  If no file exists the div on that page is not displayed.

The user interface details in the card are aimed towards the long-term goal of displaying the results on some kind of landing page, I've left a comment for Maria asking if the way it's implemented here is OK or if she'd like it to look different.