### PR TITLE
added button and url for early vote site address error report

### DIFF
--- a/pg/csv.js
+++ b/pg/csv.js
@@ -211,7 +211,7 @@ var pollingLocationAddressReport = function(req, res) {
 }
 
 var earlyVoteSiteAddressReport = function(req, res) {
-  var header = ["Early Vote Site Name", "Address Location Name", "Address Line 1", "Address Line 2", "Address Line 3", "Address City", "Address State",  "Address Zip", "Polling Location Id"];
+  var header = ["Locality Name", "Early Vote Site Name", "Address Location Name", "Address Line 1", "Address Line 2", "Address Line 3", "Address City", "Address State",  "Address Zip", "Polling Location Id"];
   var feedid = decodeURIComponent(req.params.feedid);
   conn.query(function(client) {
 
@@ -224,7 +224,8 @@ var earlyVoteSiteAddressReport = function(req, res) {
     var query = client.query('select * from v3_dashboard.early_vote_location_address_report($1)', [feedid]);
 
     query.on("row", function(row, result) {
-      res.write(makeCSVRow([row.early_vote_site_name,
+      res.write(makeCSVRow([row.locality_name,
+                            row.early_vote_site_name,
                             row.address_location_name,
                             row.address_line1,
                             row.address_line2,

--- a/pg/csv.js
+++ b/pg/csv.js
@@ -208,7 +208,37 @@ var pollingLocationAddressReport = function(req, res) {
       res.end();
     });
   });
+}
 
+var earlyVoteSiteAddressReport = function(req, res) {
+  var header = ["Early Vote Site Name", "Address Location Name", "Address Line 1", "Address Line 2", "Address Line 3", "Address City", "Address State",  "Address Zip", "Polling Location Id"];
+  var feedid = decodeURIComponent(req.params.feedid);
+  conn.query(function(client) {
+
+    res.header("Content-Disposition", "attachment; filename=" + csvFilename(feedid, 'EarlyVoteSiteAddress'));
+    res.setHeader('Content-type', 'text/csv');
+    res.charset = 'UTF-8';
+
+    res.write(makeCSVRow(header));
+
+    var query = client.query('select * from v3_dashboard.early_vote_location_address_report($1)', [feedid]);
+
+    query.on("row", function(row, result) {
+      res.write(makeCSVRow([row.early_vote_site_name,
+                            row.address_location_name,
+                            row.address_line1,
+                            row.address_line2,
+                            row.address_line3,
+                            row.address_city,
+                            row.address_state,
+                            row.address_zip,
+                            row.polling_location_id]));
+    });
+
+    query.on("end", function(result) {
+      res.end();
+    });
+  });
 }
 
 module.exports = {
@@ -220,5 +250,6 @@ module.exports = {
   },
   xmlTreeValidationErrorReport: xmlTreeValidationErrorReport,
   scopedXmlTreeValidationErrorReport: scopedXmlTreeValidationErrorReport,
-  pollingLocationAddressReport: pollingLocationAddressReport
+  pollingLocationAddressReport: pollingLocationAddressReport,
+  earlyVoteSiteAddressReport: earlyVoteSiteAddressReport
 }

--- a/pg/services.js
+++ b/pg/services.js
@@ -42,6 +42,7 @@ function registerPostgresServices (app) {
   app.get('/db/feeds/:feedid/overview/localities/errors/report', csv.scopedErrorReport("localities"));
   app.get('/db/feeds/:feedid/overview/pollinglocations/errors/report', csv.scopedErrorReport("polling-locations"));
   app.get('/db/feeds/:feedid/overview/pollinglocations/errors/address/report', csv.pollingLocationAddressReport);
+  app.get('/db/feeds/:feedid/overview/earlyvotesites/errors/address/report', csv.earlyVoteSiteAddressReport);
   app.get('/db/feeds/:feedid/overview/precincts/errors/report', csv.scopedErrorReport("precincts"));
   app.get('/db/feeds/:feedid/overview/precinctsplits/errors/report', csv.scopedErrorReport("precinct-splits"));
   app.get('/db/feeds/:feedid/overview/referenda/errors/report', csv.scopedErrorReport("referendums"));

--- a/public/app/partials/feed-errors.html
+++ b/public/app/partials/feed-errors.html
@@ -61,6 +61,7 @@
   <a class="button" href="{{errorReportPath}}" ng-show="errors.length">Download Error Report</a>
   <div ng-show="total_errors > 50000"><small>(Please be patient for large Error Reports to be prepared and downloaded)</small></div>
   <a class="button" href="{{pollingLocationReportPath}}" ng-show="{{pageId == 'feeds-overview-pollinglocations-errors-content'}}">Download Polling Location Address Error Report</a>
+  <a class="button" href="{{earlyVoteSiteAddressReportPath}}" ng-show="{{pageId == 'feeds-overview-earlyvotesites-errors-content'}}">Download Early Vote Site Address Error Report</a>
 
   <script type="text/ng-template" id="errorsPagination">
     <ul class="pagination ng-cloak">

--- a/public/assets/js/app/controllers/feedErrorsController.js
+++ b/public/assets/js/app/controllers/feedErrorsController.js
@@ -9,6 +9,7 @@ function FeedErrorsCtrl($scope, $rootScope, $feedsService, $feedDataPaths, $erro
 
   $rootScope.errorReportPath = "/db" + $location.path() + "/report";
   $rootScope.pollingLocationReportPath = "/db" + $location.path() + "/address/report";
+  $rootScope.earlyVoteSiteAddressReportPath = "/db" + $location.path() + "/address/report";
 
   // clear previous errors (so they don't weirdly show up on the page)
   $rootScope.errors = null;


### PR DESCRIPTION
For [this card](https://www.pivotaltracker.com/story/show/145550577) and related to [this PR](https://github.com/votinginfoproject/data-processor/pull/267) I added a button and an API endpoint to get the Early Vote Site Address report for a given feed.  It returns any address-related errors for Early Vote Sites together in a readable report grouped by the Early Vote Site i.e. if an Early Vote Site is missing both a state and zip it will be on a single line.