### PR TITLE
Fix email

### DIFF
--- a/notifications/sender.js
+++ b/notifications/sender.js
@@ -68,6 +68,7 @@ var notifyGroup = function(message, groupName, contentFn) {
   if ((typeof groupName != "string") ||
        (groupName.length < 2) ||
        (groupName.length > 5)) {
+    logger.info("groupName is bad--sending to admin group");
     groupName = config.email.adminGroup;
   };
   if (message["adminEmail"] == true) { groupName = config.email.adminGroup; }
@@ -83,7 +84,7 @@ var notifyGroup = function(message, groupName, contentFn) {
           var messageContent = contentFn(message, recipient, group);
 
           // sendMessage(messageContent);
-          logger.info("I would be sending a message with this content: " + messageContent)
+          logger.info("I would be sending a message to: " + recipient + " with this subject: " + messageContent.subject);
         }
       });
     });
@@ -118,13 +119,9 @@ module.exports = {
             logger.error('No feed found or connection issue.');
             notifyGroup(message, config.email.adminGroup, messageOptions.errorDuringProcessing);
           } else {
-            logger.info(result);
-            logger.info(result.rows[0]);
 
             var vip_id = result.rows[0]['vip_id'];
             var spec_version = new String(result.rows[0]['spec_version']);
-            logger.info("vip_id: " + vip_id);
-            logger.info("spec_version: " + spec_version);
             if (vip_id && spec_version[0] == '5'  && messageType === 'processedFeed') {
               notifyGroup(message, vip_id, messageOptions['v5processedFeed']);
             } else {

--- a/notifications/sender.js
+++ b/notifications/sender.js
@@ -118,7 +118,7 @@ module.exports = {
             logger.error('No feed found or connection issue.');
             notifyGroup(message, config.email.adminGroup, messageOptions.errorDuringProcessing);
           } else {
-            if (result.rows[0].vip_id && result.rows[0].spec_version.startsWith('5')  && messageType === 'processedFeed') {
+            if (result.rows[0].vip_id && result.rows[0].spec_version && result.rows[0].spec_version.startsWith('5')  && messageType === 'processedFeed') {
               notifyGroup(message, result.rows[0].vip_id, messageOptions['v5processedFeed']);
             } else {
               notifyGroup(message, result.rows[0].vip_id, messageOptions[messageType]);

--- a/notifications/sender.js
+++ b/notifications/sender.js
@@ -113,6 +113,8 @@ module.exports = {
 
         client.query(vip_id_query, [publicId], function(err, result) {
           done();
+          logger.info(result);
+          logger.info(result.rows[0]);
 
           if (err || result.rows.length == 0) {
             logger.error('No feed found or connection issue.');

--- a/notifications/sender.js
+++ b/notifications/sender.js
@@ -113,17 +113,22 @@ module.exports = {
 
         client.query(vip_id_query, [publicId], function(err, result) {
           done();
-          logger.info(result);
-          logger.info(result.rows[0]);
 
           if (err || result.rows.length == 0) {
             logger.error('No feed found or connection issue.');
             notifyGroup(message, config.email.adminGroup, messageOptions.errorDuringProcessing);
           } else {
-            if (result.rows[0].vip_id && result.rows[0]['spec_version'] && result.rows[0]['spec_version'].startsWith('5')  && messageType === 'processedFeed') {
-              notifyGroup(message, result.rows[0].vip_id, messageOptions['v5processedFeed']);
+            logger.info(result);
+            logger.info(result.rows[0]);
+
+            var vip_id = result.rows[0]['vip_id'];
+            var spec_version = new String(result.rows[0]['spec_version']);
+            logger.info("vip_id: " + vip_id)
+            logger.info("spec_version: " + spec_version)
+            if (vip_id && spec_version.startsWith('5')  && messageType === 'processedFeed') {
+              notifyGroup(message, vip_id, messageOptions['v5processedFeed']);
             } else {
-              notifyGroup(message, result.rows[0].vip_id, messageOptions[messageType]);
+              notifyGroup(message, vip_id, messageOptions[messageType]);
             }
           }
         });

--- a/notifications/sender.js
+++ b/notifications/sender.js
@@ -84,7 +84,7 @@ var notifyGroup = function(message, groupName, contentFn) {
           var messageContent = contentFn(message, recipient, group);
 
           // sendMessage(messageContent);
-          logger.info("I would be sending a message to: " + recipient + " with this subject: " + messageContent.subject);
+          logger.info("I would be sending a message to: " + messageContent.to + " with this subject: " + messageContent.subject);
         }
       });
     });

--- a/notifications/sender.js
+++ b/notifications/sender.js
@@ -120,7 +120,7 @@ module.exports = {
             logger.error('No feed found or connection issue.');
             notifyGroup(message, config.email.adminGroup, messageOptions.errorDuringProcessing);
           } else {
-            if (result.rows[0].vip_id && result.rows[0].spec_version && result.rows[0].spec_version.startsWith('5')  && messageType === 'processedFeed') {
+            if (result.rows[0].vip_id && result.rows[0]['spec_version'] && result.rows[0]['spec_version'].startsWith('5')  && messageType === 'processedFeed') {
               notifyGroup(message, result.rows[0].vip_id, messageOptions['v5processedFeed']);
             } else {
               notifyGroup(message, result.rows[0].vip_id, messageOptions[messageType]);

--- a/notifications/sender.js
+++ b/notifications/sender.js
@@ -123,9 +123,9 @@ module.exports = {
 
             var vip_id = result.rows[0]['vip_id'];
             var spec_version = new String(result.rows[0]['spec_version']);
-            logger.info("vip_id: " + vip_id)
-            logger.info("spec_version: " + spec_version)
-            if (vip_id && spec_version.startsWith('5')  && messageType === 'processedFeed') {
+            logger.info("vip_id: " + vip_id);
+            logger.info("spec_version: " + spec_version);
+            if (vip_id && spec_version.toString().startsWith('5')  && messageType === 'processedFeed') {
               notifyGroup(message, vip_id, messageOptions['v5processedFeed']);
             } else {
               notifyGroup(message, vip_id, messageOptions[messageType]);

--- a/notifications/sender.js
+++ b/notifications/sender.js
@@ -118,7 +118,7 @@ module.exports = {
             logger.error('No feed found or connection issue.');
             notifyGroup(message, config.email.adminGroup, messageOptions.errorDuringProcessing);
           } else {
-            if (result.rows[0].vip_id && results.rows[0].spec_version.startsWith('5')  && messageType === 'processedFeed') {
+            if (result.rows[0].vip_id && result.rows[0].spec_version.startsWith('5')  && messageType === 'processedFeed') {
               notifyGroup(message, result.rows[0].vip_id, messageOptions['v5processedFeed']);
             } else {
               notifyGroup(message, result.rows[0].vip_id, messageOptions[messageType]);

--- a/notifications/sender.js
+++ b/notifications/sender.js
@@ -83,8 +83,8 @@ var notifyGroup = function(message, groupName, contentFn) {
           var recipient = accounts.items[i];
           var messageContent = contentFn(message, recipient, group);
 
-          // sendMessage(messageContent);
-          logger.info("I would be sending a message to: " + messageContent.to + " with this subject: " + messageContent.subject);
+          sendMessage(messageContent);
+          logger.info("Sending a message to: " + messageContent.to + " with this subject: " + messageContent.subject);
         }
       });
     });

--- a/notifications/sender.js
+++ b/notifications/sender.js
@@ -125,7 +125,7 @@ module.exports = {
             var spec_version = new String(result.rows[0]['spec_version']);
             logger.info("vip_id: " + vip_id);
             logger.info("spec_version: " + spec_version);
-            if (vip_id && spec_version.toString().startsWith('5')  && messageType === 'processedFeed') {
+            if (vip_id && spec_version[0] == '5'  && messageType === 'processedFeed') {
               notifyGroup(message, vip_id, messageOptions['v5processedFeed']);
             } else {
               notifyGroup(message, vip_id, messageOptions[messageType]);


### PR DESCRIPTION
Changes to fix phantom emails--the variables used to figure out what group to send emails to were mis-configured and all v5.1 feed emails were getting sent to all users or at least to a lot of people who should not have been getting them.  This fixes the db query to get the `vip_id` and `spec_version` from the `results` table and adds a different check to confirm the spec version since we are no longer calling them `v3_vip_id` and `v5_vip_id` in the query.

We are also now logging emails (recipient and subject line).