### PR TITLE
fixed fileName and bucketName to match conventions on batt

### DIFF
--- a/data-testing/aws.js
+++ b/data-testing/aws.js
@@ -30,8 +30,8 @@ module.exports = {
         if (groupName === undefined) {
           groupName = "undefined"
         };
-        var bucketName = 'address-testing/' + groupName + '/input';
-        var fileName = files.file.originalFilename;
+        var bucketName = 'address-testing';
+        var fileName = groupName + '/input/' + files.file.originalFilename;
         s3.putObject({
           Bucket: bucketName,
           Key: fileName,


### PR DESCRIPTION
There was a mismatch between here and the batch-address-test-tool in how we were naming files for s3 (i.e. `bucketName` = `address-testing/<groupName>/<input/output>` with `fileName` = `<some_file>.csv` vs. `bucketName` = `address-testing` with `fileName` = `<groupName>/<input/output>/<some_file>.csv`); the second one is cleaner for `batch-address-test-tool` (i.e. we can construct the name for the output file more easily in this form) so that's what I'm going with.  Batch-Address-Test-Tool PR [here](https://github.com/votinginfoproject/batch-address-test-tool/pull/6)