### PR TITLE
Precinct error report

### DIFF
--- a/pg/services.js
+++ b/pg/services.js
@@ -112,7 +112,7 @@ function registerPostgresServices (app) {
   app.get('/db/feeds/:feedid/xml/errors/state/report',
           csv.scopedXmlTreeValidationErrorReport('State'));
   app.get('/db/feeds/:feedid/xml/errors/precincts/report',
-          csv.scopedXmlTreeValidationErrorReport('Precincts'));
+          csv.scopedXmlTreeValidationErrorReport('Precinct'));
   app.get('/db/feeds/:feedid/xml/errors/polling_locations/report',
           csv.scopedXmlTreeValidationErrorReport('PollingLocation'));
   app.get('/db/feeds/:feedid/xml/errors/localities/report',


### PR DESCRIPTION
For [this bug](https://www.pivotaltracker.com/story/show/147303665) I figured out that the precinct error report couldn't find precinct errors because it was using 'Precincts' instead of 'Precinct'. I'm going to make sure to see if there are other problematic plurals in the way we generate `scopedXmlTreeValidationReport` but I also wanted to get this PR'd and taken care of first.