### PR TITLE
Env specific batt buckets

### DIFF
--- a/config.js
+++ b/config.js
@@ -77,4 +77,8 @@ config.vit = {
   apiKey: process.env.VIT_API_KEY
 }
 
+config.batt = {
+  batchAddressBucket: process.env.VIP_BATT_BUCKET_NAME
+}
+
 module.exports = config;

--- a/data-testing/aws.js
+++ b/data-testing/aws.js
@@ -7,6 +7,7 @@ var queue = require('./queue')
 var logger = (require('../logging/vip-winston')).Logger;
 
 AWS.config.update({ accessKeyId: config.aws.accessKey, secretAccessKey: config.aws.secretKey });
+var batchAddressBucket = config.batt.batchaAddressBucket;
 
 module.exports = {
   uploadAddressFile: function(req, res){
@@ -31,7 +32,7 @@ module.exports = {
         if (groupName === undefined) {
           groupName = "undefined"
         };
-        var bucketName = 'address-testing';
+        var bucketName = batchAddressBucket;
         var fileName = groupName + '/input/' + files.file.originalFilename;
         logger.info("putting file with name '" + fileName + "' into bucket '" + bucketName + "'");
         s3.putObject({
@@ -58,7 +59,7 @@ module.exports = {
     if (groupName === undefined) {
       groupName = "undefined";
     }
-    var bucketName = 'address-testing';
+    var bucketName = batchAddressBucket;
     var fileName  = groupName + "/output/results.csv"
 
     var params = {

--- a/data-testing/aws.js
+++ b/data-testing/aws.js
@@ -7,7 +7,7 @@ var queue = require('./queue')
 var logger = (require('../logging/vip-winston')).Logger;
 
 AWS.config.update({ accessKeyId: config.aws.accessKey, secretAccessKey: config.aws.secretKey });
-var batchAddressBucket = config.batt.batchaAddressBucket;
+var batchAddressBucket = config.batt.batchAddressBucket;
 
 module.exports = {
   uploadAddressFile: function(req, res){

--- a/metis@.service.template
+++ b/metis@.service.template
@@ -42,6 +42,7 @@ ExecStartPre=/bin/bash -c 'echo NEW_RELIC_ENVIRONMENT="$(curl -s http://${COREOS
 ExecStartPre=/bin/bash -c 'echo VIT_API_KEY="$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/data-suite/google-civic/api-key?raw)" >> /tmp/${CONTAINER}--env'
 ExecStartPre=/bin/bash -c 'echo VIP_DP_AWS_ACCESS_KEY="$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/data-suite/aws/access-key?raw)" >> /tmp/${CONTAINER}--env'
 ExecStartPre=/bin/bash -c 'echo VIP_DP_AWS_SECRET_KEY="$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/data-suite/aws/secret-key?raw)" >> /tmp/${CONTAINER}--env'
+ExecStartPre=/bin/bash -c 'echo VIP_BATT_BUCKET_NAME="$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/data-suite/batch-addres-test-tool/address-testing-bucket?raw)" >> /tmp/${CONTAINER}--env'
 
 ExecStart=/bin/bash -c 'docker run --name ${CONTAINER} \
   --link rabbitmq:rabbitmq \


### PR DESCRIPTION
This PR puts the bucket name used by the Batch Address Test Tool (which is dictated by the bucket Metis uploads to; it uploads the file submitted by the user and sends the message to the BATT telling it where the file it should process is) into consul to make sure that staging and production aren't using the same buckets (they were before).