### PR TITLE
Correct the auth flow to use access token

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -89,6 +89,10 @@ module.exports = function(grunt) {
         {
           from: 'AUTH0_REDIRECT_URI_DASHBOARD',
           to: process.env.AUTH0_REDIRECT_URI_DASHBOARD
+        },
+        {
+          from: 'AUTH0_AUDIENCE_DASHBOARD',
+          to: process.env.AUTH0_AUDIENCE_DASHBOARD
         }]
       }
     },

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ RABBITMQ_PORT_5672_TCP_PORT=5672
 VIP_DP_RABBITMQ_EXCHANGE=data-processor-exchange
 AUTH0_CLIENT_ID_EXPRESS=some-client-id
 AUTH0_CLIENT_SECRET_EXPRESS=some-client-id
-AUTH0_AUDIENCE_EXPRESS=some-audience
+AUTH0_AUDIENCE_EXPRESS=some-audience-uri
 AUTH0_DOMAIN_EXPRESS=some.auth0.com
 ```
 
@@ -85,7 +85,8 @@ You have a couple of options to run locally. You can use node directly, or you c
 * It monitors changes in html/sass/js files and restarts the node app
 * Most importantly, it builds an config.js file for the Angular app to facilitate logging into Auth0. However, you need to put all the same AUTH0 env vars above into your local environment, or put them at the front of the command. An easy way to run it is with a `run-local` script that puts your env vars before the command, like this:
 ```
-AUTH0_DOMAIN_DASHBOARD=<auth0_domain> AUTH0_CLIENT_ID_DASHBOARD=<auth0_client_id>  AUTH0_REDIRECT_URI_DASHBOARD="http://localhost:4000/#/login-callback" ./node_modules/.bin/grunt default
+AUTH0_DOMAIN_DASHBOARD=<auth0_domain> AUTH0_CLIENT_ID_DASHBOARD=<auth0_client_id>  AUTH0_REDIRECT_URI_DASHBOARD="http://localhost:4000/#/login-callback"
+AUTH0_AUDIENCE_DASHBOARD="some-audience-uri" ./node_modules/.bin/grunt default
 ```
 
 Grunt:

--- a/metis@.service.template
+++ b/metis@.service.template
@@ -42,9 +42,11 @@ ExecStartPre=/bin/bash -c 'echo VIP_DP_AWS_SECRET_KEY="$(curl -s http://${COREOS
 ExecStartPre=/bin/bash -c 'echo AUTH0_DOMAIN_DASHBOARD="$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/data-suite/auth0/dashboard/domain?raw)" >> /tmp/${CONTAINER}--env'
 ExecStartPre=/bin/bash -c 'echo AUTH0_CLIENT_ID_DASHBOARD="$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/data-suite/auth0/dashboard/client-id?raw)" >> /tmp/${CONTAINER}--env'
 ExecStartPre=/bin/bash -c 'echo AUTH0_REDIRECT_URI_DASHBOARD="$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/data-suite/auth0/dashboard/redirect-uri?raw)" >> /tmp/${CONTAINER}--env'
+ExecStartPre=/bin/bash -c 'echo AUTH0_AUDIENCE_DASHBOARD="$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/data-suite/auth0/dashboard/audience?raw)" >> /tmp/${CONTAINER}--env'
 ExecStartPre=/bin/bash -c 'echo AUTH0_DOMAIN_EXPRESS="$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/data-suite/auth0/express/domain?raw)" >> /tmp/${CONTAINER}--env'
 ExecStartPre=/bin/bash -c 'echo AUTH0_CLIENT_ID_EXPRESS="$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/data-suite/auth0/express/client-id?raw)" >> /tmp/${CONTAINER}--env'
 ExecStartPre=/bin/bash -c 'echo AUTH0_CLIENT_SECRET_EXPRESS="$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/data-suite/auth0/express/client-secret?raw)" >> /tmp/${CONTAINER}--env'
+ExecStartPre=/bin/bash -c 'echo AUTH0_AUDIENCE_EXPRESS="$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/data-suite/auth0/express/audience?raw)" >> /tmp/${CONTAINER}--env'
 ExecStartPre=/bin/bash -c 'echo VIP_BATT_BUCKET_NAME="$(curl -s http://${COREOS_PRIVATE_IPV4}:8500/v1/kv/data-suite/batch-address-test-tool/address-testing-bucket?raw)" >> /tmp/${CONTAINER}--env'
 
 ExecStart=/bin/bash -c 'docker run --name ${CONTAINER} \

--- a/public/assets/js/app/config.js.template
+++ b/public/assets/js/app/config.js.template
@@ -4,6 +4,7 @@ config.auth0 = {
   clientID: 'AUTH0_CLIENT_ID_DASHBOARD',
   domain: 'AUTH0_DOMAIN_DASHBOARD',
   responseType: 'token id_token',
+  audience: 'AUTH0_AUDIENCE_DASHBOARD',
   redirectUri: 'AUTH0_REDIRECT_URI_DASHBOARD',
   scope: 'openid'
 };

--- a/public/assets/js/app/services/authService.js
+++ b/public/assets/js/app/services/authService.js
@@ -34,7 +34,7 @@ vipApp.factory('$authService', function ($rootScope, $location, $timeout, $http,
 
   function setupAuthentication() {
     console.log("beginning of setupAuthentication");
-    $http.defaults.headers.common['Authorization'] = 'Bearer ' + getIdToken();
+    $http.defaults.headers.common['Authorization'] = 'Bearer ' + getAccessToken();
     getUser($appService.setUserSuccess, $appService.setUserFailure);
     $rootScope.logoutUrl = createLogoutUrl();
     if($location.url() === "/" || $location.url() === "" ||


### PR DESCRIPTION
This is apparently the more secure way to do things, based on feedback from Auth0.

You'll need to create an API in each of the tenants,
and then you can control the expiration time of
the access token via the API settings. Take the 
audience value of the API and set it as the audience
for both AUTH0_AUDIENCE_DASHBOARD and
AUTH0_AUDIENCE_EXPRESS.

[Pivotal Card](https://www.pivotaltracker.com/story/show/150179594) to cover finishing this work.