### PR TITLE
Fix auth

### DIFF
--- a/authentication/services.js
+++ b/authentication/services.js
@@ -32,29 +32,14 @@ var authClient = new AuthenticationClient({
   clientSecret: config.auth0.secret
 });
 
-function getUserFromAccessToken(accessToken, successCB, failureCB) {
-  console.log("getUser for accessToken");
-  authClient.users.getInfo(accessToken, function(err, user) {
-    if (err) {
-      console.log("getUser error");
-      failureCB(err);
-    } else {
-      console.log("getUser success");
-      successCB(user);
-    }
-  });
-}
-
 function registerAuthServices(app) {
-  app.post('/services/getUser', checkJwt, function(req, res) {
-    getUserFromAccessToken(req.body.accessToken,
-    function(user){
-      res.status(200).send(user);
-    },
-    function(err) {
-      console.log(err);
-      res.status(401).send("Unauthenticated");
-    });
+  app.post('/services/getMetadata', checkJwt, function(req, res) {
+    console.log(JSON.stringify(req.user));
+    var metadata = {"user_metadata":
+                    {"givenName": req.user["https://dashboard.votinginfoproject.org/givenName"]},
+                    "app_metadata":
+                    {"fipsCodes": req.user["https://dashboard.votinginfoproject.org/fipsCodes"]}}
+    res.status(200).send(metadata);
   });
 }
 
@@ -99,6 +84,5 @@ function getUsersByFips(fips, cb) {
 
 exports.checkJwt = checkJwt;
 exports.checkAuth = checkAuth;
-exports.getUserFromAccessToken = getUserFromAccessToken;
 exports.registerAuthServices = registerAuthServices;
 exports.getUsersByFips = getUsersByFips;

--- a/public/assets/js/app/config.js.template
+++ b/public/assets/js/app/config.js.template
@@ -6,5 +6,5 @@ config.auth0 = {
   responseType: 'token id_token',
   audience: 'AUTH0_AUDIENCE_DASHBOARD',
   redirectUri: 'AUTH0_REDIRECT_URI_DASHBOARD',
-  scope: 'openid'
+  scope: 'openid profile'
 };

--- a/public/assets/js/app/controllers/feedsController.js
+++ b/public/assets/js/app/controllers/feedsController.js
@@ -12,6 +12,7 @@ function FeedsCtrl($scope, $rootScope, $feedDataPaths, $feedsService, $location,
 
   var getFeedResponse = function() {
     $authService.getUser(function (user){
+      console.log("loading feeds for " + user.fipsCodes);
       $feedDataPaths.getResponse(
         {path: "/db/feeds",
          config: {'params': {'page': $rootScope.page,


### PR DESCRIPTION
There are a couple of things going on now.

* We request the profile as part of the response (see change in `config.js.template`). This gives us a reduced/standardized form of the profile, so it doesn't include any of the metadata.
* The recommended way to send metadata is to use Rules to attach it to the access token. And to do so, we have to use keys that look like URIs, and should be unique. I've created rules in local/staging/prod to copy the pieces of metadata we are interested in, givenName and fipsCode, over into the access token.
* Changed `/getUser` to `/getMetadata`, since now it decodes the access token, looks up the pieces of metadata we've copied into it, and returns it to the Angular app.
* Build the local user data off of the standardized profile components and the metadata.