### PR TITLE
fixing codeToDescription function to get state name from codes not from fips

### DIFF
--- a/notifications/content.js
+++ b/notifications/content.js
@@ -53,7 +53,7 @@ var codes = {
   "56": "Wyoming"}
 
 function codeToDescription (code) {
-  return fips.code;
+  return codes.code;
 };
 
 var getGivenName = function(recipient) {


### PR DESCRIPTION
Our codeToDescription function was not using the data structure with fips codes and state names correctly; it was calling it `fips` instead of `codes`.