### PR TITLE
search for feeds starting with matching fipscodes

### DIFF
--- a/pg/gets.js
+++ b/pg/gets.js
@@ -19,14 +19,15 @@ module.exports = {
         return [req.query.page];
       })(req, res);
     } else {
-      return util.simpleQueryResponder(queries.feedsForState, function(req) {
+      return util.simpleQueryResponder(queries.feedsForFipsCodes, function(req) {
         var fipsCodes = null;
         if (typeof req.query.fipsCodes === 'string'){
           fipsCodes = [req.query.fipsCodes];
         } else {
           fipsCodes = req.query.fipsCodes;
         }
-        return [fipsCodes, req.query.page];
+        likeFipsCodes = fipsCodes.map(function (code) { return code + "%"});
+        return [likeFipsCodes, req.query.page];
       })(req, res);
     }
   },

--- a/pg/queries.js
+++ b/pg/queries.js
@@ -33,12 +33,12 @@ module.exports = {
           FROM results r \
           ORDER BY r.id DESC \
           LIMIT 20 OFFSET ($1 * 20);",
-  feedsForState: "SELECT r.public_id, r.start_time, date(r.end_time) AS end_time, \
-                         CASE WHEN r.end_time IS NOT NULL \
-                              THEN r.end_time - r.start_time END AS duration, \
-                         r.spec_version, r.complete, r.state, r.election_type, r.election_date \
+  feedsForFipsCodes: "SELECT r.public_id, r.start_time, date(r.end_time) AS end_time, \
+                             CASE WHEN r.end_time IS NOT NULL \
+                                  THEN r.end_time - r.start_time END AS duration, \
+                             r.spec_version, r.complete, r.state, r.election_type, r.election_date \
                   FROM results r \
-                  WHERE substr(r.vip_id, 0, 3) = ANY ($1) \
+                  WHERE r.vip_id LIKE ANY ($1) \
                   ORDER BY r.start_time DESC \
                   LIMIT 20 OFFSET ($2 * 20);",
   results: "SELECT * FROM results WHERE public_id=$1",


### PR DESCRIPTION
* allows state level users to see county level feeds
* county level users only see county level feeds

This works if we just use 5 digit fipsCodes in the app_metadata, i.e.

```
{
  "fipsCodes": {"06023": true}
}
```

[Pivotal Card](https://www.pivotaltracker.com/story/show/149816858)