### PR TITLE
adding roles to users from Auth0, filtering county data button by role

### DIFF
--- a/authentication/services.js
+++ b/authentication/services.js
@@ -38,7 +38,8 @@ function registerAuthServices(app) {
     var metadata = {"user_metadata":
                     {"givenName": req.user["https://dashboard.votinginfoproject.org/givenName"]},
                     "app_metadata":
-                    {"fipsCodes": req.user["https://dashboard.votinginfoproject.org/fipsCodes"]}}
+                    {"fipsCodes": req.user["https://dashboard.votinginfoproject.org/fipsCodes"],
+                     "roles": req.user["https://dashboard.votinginfoproject.org/roles"]}}
     res.status(200).send(metadata);
   });
 }

--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "vkBeautify": "https://github.com/vkiryukhin/vkBeautify.git",
     "ng-file-upload": "12.2.13",
     "angular-auth0": "2.0.0",
-    "angular-ui-date": "^1.0.1"
+    "angular-ui-date": "1.0.1"
   },
   "ignoredByBower": {
     "quickCopyAndPasteOfPotentialAngularDependencies": {

--- a/public/assets/js/app/controllers/homeController.js
+++ b/public/assets/js/app/controllers/homeController.js
@@ -16,4 +16,5 @@ function HomeCtrl($scope, $rootScope, $homeService, $location, $routeParams, $au
   $scope.login = function() {
   	$authService.login();
   };
+  $rootScope.hasRole = $authService.hasRole;
 }

--- a/public/assets/js/app/services/authService.js
+++ b/public/assets/js/app/services/authService.js
@@ -80,6 +80,15 @@ vipApp.factory('$authService', function ($rootScope, $location, $timeout, $http,
     return localStorage.getItem('auth0_id_token');
   }
 
+  function getLocalUser(){
+    var storedUser = localStorage.getItem('auth0_user');
+    if (storedUser) {
+      return JSON.parse(storedUser);
+    } else {
+      return null;
+    }
+  };
+
   function getUser(successCallback, failureCallback) {
     var storedUser = localStorage.getItem('auth0_user');
     if (storedUser) {
@@ -103,7 +112,8 @@ vipApp.factory('$authService', function ($rootScope, $location, $timeout, $http,
             givenName: userToGivenName(metadata.user_metadata, profile),
             userName: profile["name"],
             email: profile["email"],
-            fipsCodes: userToFips(metadata.app_metadata)
+            fipsCodes: userToFips(metadata.app_metadata),
+            roles: userToRoles(metadata.app_metadata)
     }
   };
 
@@ -111,6 +121,15 @@ vipApp.factory('$authService', function ($rootScope, $location, $timeout, $http,
     if (metadata && metadata.fipsCodes) {
       return Object.keys(metadata.fipsCodes);
     } else {
+      return [];
+    }
+  };
+
+  function userToRoles(metadata) {
+    if (metadata && metadata.roles) {
+      return metadata.roles;
+    } else {
+      console.log("no roles in metadata");
       return [];
     }
   };
@@ -129,6 +148,16 @@ vipApp.factory('$authService', function ($rootScope, $location, $timeout, $http,
     }
   }
 
+  function hasRole (roleName) {
+    var user = getLocalUser();
+    if (user) {
+      var roles = user.roles;
+      if (roles.indexOf(roleName) >= 0) {
+        return true;
+      }
+    }
+    return false;
+  };
 
   return {
     login: login,
@@ -138,6 +167,7 @@ vipApp.factory('$authService', function ($rootScope, $location, $timeout, $http,
     isAuthenticated: isAuthenticated,
     getAccessToken: getAccessToken,
     getIdToken: getIdToken,
-    getUser: getUser
+    getUser: getUser,
+    hasRole: hasRole
   }
 });

--- a/public/index.html
+++ b/public/index.html
@@ -173,7 +173,7 @@
           <li><i class="fi-torso"></i> {{user.userName}}</li>
           <li><a id="pageHeader-feedsLink" href="#/feeds" alert-box error ng-class="{'is-active': pageHeader.section=='feeds'}"><i class="fi-list"></i> Feeds</a></li>
           <li><a id="pageHeader-testing" href="#/testing/vit"><i class="fi-clipboard-pencil"></i> Staging Data Review</a></li>
-          <li ng-if="true"><a id="pageHeader-county-data" href="#/county-data/centralization"><i class="fi-upload"></i> County Data Uploads</a></li>
+          <li ng-if="hasRole('data-centralization')"><a id="pageHeader-county-data" href="#/county-data/centralization"><i class="fi-upload"></i> County Data Uploads</a></li>
           <li><a id="pageHeader-sign-out" href="{{logoutUrl}}"><i class="fi-x"></i> Sign Out</a></li>
         </ul>
       </nav>


### PR DESCRIPTION
We've added county users to the database by adding `roles` to the `app_metadata` such that a county user has ` {roles: ["data-centralization"]}` attached to their user in Auth0.  This code uses that data along with a function in the `authServices` file that checks if a user has a given role (this will be useful in future work to show different data and different kinds of data in the data-centralization section based on whether a user is a state admin or a superadmin or what have you).