### PR TITLE
Ballot measure contest errors

### DIFF
--- a/pg/csv.js
+++ b/pg/csv.js
@@ -85,7 +85,7 @@ var scopedXmlTreeValidationQuery = function(elementTypes) {
  WHERE r.public_id = $1 AND v.path ~ 'VipObject.0." + elementTypes.join("|") + ".*'";
 }
 
-var ballotMeasureContestScopedXmlTreeValidationQuery = function() {
+var elementTypeAndScopeXmlTreeValidationQuery = function(elementTypes, scope) {
   return "SELECT v.severity, v.scope, v.path, v.parent_element_id AS identifier, \
         v.error_type, v.error_data \
  FROM xml_tree_validations v \
@@ -93,22 +93,22 @@ var ballotMeasureContestScopedXmlTreeValidationQuery = function() {
  WHERE r.public_id = $1 AND (v.path ~ 'VipObject.0.BallotMeasureContest.*' or v.scope like 'ballot-measure-contest%')";
 }
 
-var ballotMeasureContestScopedXmlTreeValidationErrorReport = function() {
-  var elementTypes = Array.prototype.slice.call(arguments);
+var elementTypeAndScopeXmlTreeValidationErrorReport = function(elementType, scope) {
+  // var elementTypes = Array.prototype.slice.call(arguments);
 
   return function(req, res) {
     var header = ["Feed", "Severity", "Scope", "Path", "ID", "Error Type", "Error Data"];
     var feedid = decodeURIComponent(req.params.feedid);
 
     conn.query(function(client) {
-      res.header("Content-Disposition", "attachment; filename=" + csvFilename(feedid, elementTypes[0]));
+      res.header("Content-Disposition", "attachment; filename=" + csvFilename(feedid, elementType));
       res.setHeader('Content-type', 'text/csv');
       res.charset = 'UTF-8';
 
       res.write(makeCSVRow(header));
       // res.end();
 
-      var query = client.query(ballotMeasureContestScopedXmlTreeValidationQuery(), [feedid]);
+      var query = client.query(elementTypeAndScopeXmlTreeValidationQuery(elementType, scope), [feedid]);
 
       query.on("row", function(row, result) {
         res.write(makeCSVRow([feedid,
@@ -295,5 +295,5 @@ module.exports = {
   scopedXmlTreeValidationErrorReport: scopedXmlTreeValidationErrorReport,
   pollingLocationAddressReport: pollingLocationAddressReport,
   earlyVoteSiteAddressReport: earlyVoteSiteAddressReport,
-  ballotMeasureContestScopedXmlTreeValidationErrorReport: ballotMeasureContestScopedXmlTreeValidationErrorReport
+  elementTypeAndScopeXmlTreeValidationErrorReport: elementTypeAndScopeXmlTreeValidationErrorReport
 }

--- a/pg/csv.js
+++ b/pg/csv.js
@@ -94,7 +94,6 @@ var elementTypeAndScopeXmlTreeValidationQuery = function(elementType, scope) {
 }
 
 var elementTypeAndScopeXmlTreeValidationErrorReport = function(elementType, scope) {
-  // var elementTypes = Array.prototype.slice.call(arguments);
 
   return function(req, res) {
     var header = ["Feed", "Severity", "Scope", "Path", "ID", "Error Type", "Error Data"];
@@ -106,7 +105,6 @@ var elementTypeAndScopeXmlTreeValidationErrorReport = function(elementType, scop
       res.charset = 'UTF-8';
 
       res.write(makeCSVRow(header));
-      // res.end();
 
       var query = client.query(elementTypeAndScopeXmlTreeValidationQuery(elementType, scope), [feedid]);
 

--- a/pg/csv.js
+++ b/pg/csv.js
@@ -85,12 +85,12 @@ var scopedXmlTreeValidationQuery = function(elementTypes) {
  WHERE r.public_id = $1 AND v.path ~ 'VipObject.0." + elementTypes.join("|") + ".*'";
 }
 
-var elementTypeAndScopeXmlTreeValidationQuery = function(elementTypes, scope) {
+var elementTypeAndScopeXmlTreeValidationQuery = function(elementType, scope) {
   return "SELECT v.severity, v.scope, v.path, v.parent_element_id AS identifier, \
         v.error_type, v.error_data \
  FROM xml_tree_validations v \
  INNER JOIN results r ON r.id = v.results_id \
- WHERE r.public_id = $1 AND (v.path ~ 'VipObject.0.BallotMeasureContest.*' or v.scope like 'ballot-measure-contest%')";
+ WHERE r.public_id = $1 AND (v.path ~ 'VipObject.0."+ elementType + ".*' or v.scope like '" + scope + "%')";
 }
 
 var elementTypeAndScopeXmlTreeValidationErrorReport = function(elementType, scope) {

--- a/pg/csv.js
+++ b/pg/csv.js
@@ -85,6 +85,48 @@ var scopedXmlTreeValidationQuery = function(elementTypes) {
  WHERE r.public_id = $1 AND v.path ~ 'VipObject.0." + elementTypes.join("|") + ".*'";
 }
 
+var ballotMeasureContestScopedXmlTreeValidationQuery = function(elementTypes, scope) {
+  return "SELECT v.severity, v.scope, v.path, v.parent_element_id AS identifier, \
+        v.error_type, v.error_data \
+ FROM xml_tree_validations v \
+ INNER JOIN results r ON r.id = v.results_id \
+ WHERE r.public_id = $1 AND (v.path ~ 'VipObject.0.BallotMeasureContest.*' or v.scope like 'ballot-measure-contest%')";
+}
+
+var ballotMeasureContestScopedXmlTreeValidationErrorReport = function() {
+  var elementTypes = Array.prototype.slice.call(arguments);
+
+  return function(req, res) {
+    var header = ["Feed", "Severity", "Scope", "Path", "ID", "Error Type", "Error Data"];
+    var feedid = decodeURIComponent(req.params.feedid);
+
+    conn.query(function(client) {
+      res.header("Content-Disposition", "attachment; filename=" + csvFilename(feedid, elementTypes[0]));
+      res.setHeader('Content-type', 'text/csv');
+      res.charset = 'UTF-8';
+
+      res.write(makeCSVRow(header));
+      // res.end();
+
+      var query = client.query(ballotMeasureContestScopedXmlTreeValidationQuery(elementTypes, "ballot-measure-contest"), [feedid]);
+
+      query.on("row", function(row, result) {
+        res.write(makeCSVRow([feedid,
+                              row.severity,
+                              row.scope,
+                              row.path,
+                              row.identifier,
+                              row.error_type,
+                              row.error_data]));
+      });
+
+      query.on("end", function(result) {
+        res.end();
+      });
+    });
+  };
+}
+
 var scopedXmlTreeValidationErrorReport = function() {
   var elementTypes = Array.prototype.slice.call(arguments);
 
@@ -252,5 +294,6 @@ module.exports = {
   xmlTreeValidationErrorReport: xmlTreeValidationErrorReport,
   scopedXmlTreeValidationErrorReport: scopedXmlTreeValidationErrorReport,
   pollingLocationAddressReport: pollingLocationAddressReport,
-  earlyVoteSiteAddressReport: earlyVoteSiteAddressReport
+  earlyVoteSiteAddressReport: earlyVoteSiteAddressReport,
+  ballotMeasureContestScopedXmlTreeValidationErrorReport: ballotMeasureContestScopedXmlTreeValidationErrorReport
 }

--- a/pg/csv.js
+++ b/pg/csv.js
@@ -85,7 +85,7 @@ var scopedXmlTreeValidationQuery = function(elementTypes) {
  WHERE r.public_id = $1 AND v.path ~ 'VipObject.0." + elementTypes.join("|") + ".*'";
 }
 
-var ballotMeasureContestScopedXmlTreeValidationQuery = function(elementTypes, scope) {
+var ballotMeasureContestScopedXmlTreeValidationQuery = function() {
   return "SELECT v.severity, v.scope, v.path, v.parent_element_id AS identifier, \
         v.error_type, v.error_data \
  FROM xml_tree_validations v \
@@ -108,7 +108,7 @@ var ballotMeasureContestScopedXmlTreeValidationErrorReport = function() {
       res.write(makeCSVRow(header));
       // res.end();
 
-      var query = client.query(ballotMeasureContestScopedXmlTreeValidationQuery(elementTypes, "ballot-measure-contest"), [feedid]);
+      var query = client.query(ballotMeasureContestScopedXmlTreeValidationQuery(), [feedid]);
 
       query.on("row", function(row, result) {
         res.write(makeCSVRow([feedid,

--- a/pg/services.js
+++ b/pg/services.js
@@ -81,7 +81,7 @@ function registerPostgresServices (app) {
   // Contests table
   app.get('/db/5.1/feeds/:feedid/overview/candidate_contests/errors', auth.checkJwt, pg51.overviewErrors("CandidateContest"));
   app.get('/db/5.1/feeds/:feedid/overview/candidate_selection/errors', auth.checkJwt, pg51.overviewErrors("CandidateSelection"));
-  app.get('/db/5.1/feeds/:feedid/overview/ballot_measure_contests/errors', auth.checkJwt, pg51.ballotMeasureOverallErrorQuery("BallotMeasureContest", 'ballot-measure-contest'));
+  app.get('/db/5.1/feeds/:feedid/overview/ballot_measure_contests/errors', auth.checkJwt, pg51.elementTypeAndScopeOverallErrorQuery("BallotMeasureContest", 'ballot-measure-contest'));
   app.get('/db/5.1/feeds/:feedid/overview/ballot_selections/errors', auth.checkJwt, pg51.overviewErrors("BallotSelection"));
   app.get('/db/5.1/feeds/:feedid/overview/retention_contests/errors', auth.checkJwt, pg51.overviewErrors("RetentionContest"));
   app.get('/db/5.1/feeds/:feedid/overview/party_contests/errors', auth.checkJwt, pg51.overviewErrors("PartyContest"));

--- a/pg/services.js
+++ b/pg/services.js
@@ -98,8 +98,7 @@ function registerPostgresServices (app) {
 
   app.get('/db/feeds/:feedid/xml/errors/report', csv.xmlTreeValidationErrorReport);
   app.get('/db/feeds/:feedid/xml/errors/candidate_selection/report', csv.scopedXmlTreeValidationErrorReport('CandidateSelection'));
-  // app.get('/db/feeds/:feedid/xml/errors/ballot_measure_contests/report', csv.test(['BallotMeasureContest']  ));
-  app.get('/db/feeds/:feedid/xml/errors/ballot_measure_contests/report', csv.ballotMeasureContestScopedXmlTreeValidationErrorReport('BallotMeasureContest', 'ballot-measure-contest'));
+  app.get('/db/feeds/:feedid/xml/errors/ballot_measure_contests/report', csv.ballotMeasureContestScopedXmlTreeValidationErrorReport('BallotMeasureContest'));
   app.get('/db/feeds/:feedid/xml/errors/ballot_selection/report', csv.scopedXmlTreeValidationErrorReport('BallotSelection'));
   app.get('/db/feeds/:feedid/xml/errors/retention_contests/report', csv.scopedXmlTreeValidationErrorReport('RetentionContest'));
   app.get('/db/feeds/:feedid/xml/errors/party_contests/report', csv.scopedXmlTreeValidationErrorReport('PartyContest'));

--- a/pg/services.js
+++ b/pg/services.js
@@ -98,7 +98,7 @@ function registerPostgresServices (app) {
 
   app.get('/db/feeds/:feedid/xml/errors/report', csv.xmlTreeValidationErrorReport);
   app.get('/db/feeds/:feedid/xml/errors/candidate_selection/report', csv.scopedXmlTreeValidationErrorReport('CandidateSelection'));
-  app.get('/db/feeds/:feedid/xml/errors/ballot_measure_contests/report', csv.ballotMeasureContestScopedXmlTreeValidationErrorReport('BallotMeasureContest'));
+  app.get('/db/feeds/:feedid/xml/errors/ballot_measure_contests/report', csv.elementTypeAndScopeXmlTreeValidationErrorReport('BallotMeasureContest', 'ballot-measure-contest'));
   app.get('/db/feeds/:feedid/xml/errors/ballot_selection/report', csv.scopedXmlTreeValidationErrorReport('BallotSelection'));
   app.get('/db/feeds/:feedid/xml/errors/retention_contests/report', csv.scopedXmlTreeValidationErrorReport('RetentionContest'));
   app.get('/db/feeds/:feedid/xml/errors/party_contests/report', csv.scopedXmlTreeValidationErrorReport('PartyContest'));

--- a/pg/services.js
+++ b/pg/services.js
@@ -98,7 +98,8 @@ function registerPostgresServices (app) {
 
   app.get('/db/feeds/:feedid/xml/errors/report', csv.xmlTreeValidationErrorReport);
   app.get('/db/feeds/:feedid/xml/errors/candidate_selection/report', csv.scopedXmlTreeValidationErrorReport('CandidateSelection'));
-  app.get('/db/feeds/:feedid/xml/errors/ballot_measure_contests/report', csv.scopedXmlTreeValidationErrorReport('BallotMeasureContest'));
+  // app.get('/db/feeds/:feedid/xml/errors/ballot_measure_contests/report', csv.test(['BallotMeasureContest']  ));
+  app.get('/db/feeds/:feedid/xml/errors/ballot_measure_contests/report', csv.ballotMeasureContestScopedXmlTreeValidationErrorReport('BallotMeasureContest', 'ballot-measure-contest'));
   app.get('/db/feeds/:feedid/xml/errors/ballot_selection/report', csv.scopedXmlTreeValidationErrorReport('BallotSelection'));
   app.get('/db/feeds/:feedid/xml/errors/retention_contests/report', csv.scopedXmlTreeValidationErrorReport('RetentionContest'));
   app.get('/db/feeds/:feedid/xml/errors/party_contests/report', csv.scopedXmlTreeValidationErrorReport('PartyContest'));

--- a/pg/services.js
+++ b/pg/services.js
@@ -81,7 +81,7 @@ function registerPostgresServices (app) {
   // Contests table
   app.get('/db/5.1/feeds/:feedid/overview/candidate_contests/errors', auth.checkJwt, pg51.overviewErrors("CandidateContest"));
   app.get('/db/5.1/feeds/:feedid/overview/candidate_selection/errors', auth.checkJwt, pg51.overviewErrors("CandidateSelection"));
-  app.get('/db/5.1/feeds/:feedid/overview/ballot_measure_contests/errors', auth.checkJwt, pg51.overviewErrors("BallotMeasureContest"));
+  app.get('/db/5.1/feeds/:feedid/overview/ballot_measure_contests/errors', auth.checkJwt, pg51.ballotMeasureOverallErrorQuery("BallotMeasureContest", 'ballot-measure-contest'));
   app.get('/db/5.1/feeds/:feedid/overview/ballot_selections/errors', auth.checkJwt, pg51.overviewErrors("BallotSelection"));
   app.get('/db/5.1/feeds/:feedid/overview/retention_contests/errors', auth.checkJwt, pg51.overviewErrors("RetentionContest"));
   app.get('/db/5.1/feeds/:feedid/overview/party_contests/errors', auth.checkJwt, pg51.overviewErrors("PartyContest"));

--- a/pg/v5_1_queries.js
+++ b/pg/v5_1_queries.js
@@ -47,7 +47,7 @@ var overallErrorQuery = function(scope) {
     return buildErrorQuery("", "element_type(xtv.path) = '" + scope + "'");
 };
 
-var ballotMeasureOverallErrorQuery = function(element_type, scope) {
+var elementTypeAndScopeOverallErrorQuery = function(element_type, scope) {
   var wheres = "(element_type(xtv.path) = '" + element_type + "' or xtv.scope like '" + scope + "%')"
   return buildErrorQuery("", wheres)
 };
@@ -200,5 +200,5 @@ module.exports = {
   overviewErrors: function(scope) { return errorResponder(overallErrorQuery(scope)); },
   localityErrorsReport: util.simpleQueryResponder(localityErrors, util.paramExtractor()),
   scopedLocalityErrors: function(scope) { return errorResponder(getScopedLocalityErrors(scope), ['localityId']); },
-  ballotMeasureOverallErrorQuery: function(element_type, scope) { return errorResponder(ballotMeasureOverallErrorQuery(element_type, scope)); }
+  elementTypeAndScopeOverallErrorQuery: function(element_type, scope) { return errorResponder(elementTypeAndScopeOverallErrorQuery(element_type, scope)); }
 }

--- a/pg/v5_1_queries.js
+++ b/pg/v5_1_queries.js
@@ -47,6 +47,11 @@ var overallErrorQuery = function(scope) {
     return buildErrorQuery("", "element_type(xtv.path) = '" + scope + "'");
 };
 
+var ballotMeasureOverallErrorQuery = function(element_type, scope) {
+  var wheres = "(element_type(xtv.path) = '" + element_type + "' or xtv.scope like '" + scope + "%')"
+  return buildErrorQuery("", wheres)
+};
+
 var getScopedLocalityErrors = function (scope) {
     return "select distinct on (xtv.severity, xtv.scope, xtv.error_type) \
                                                 count(1), xtv.severity, xtv.scope, \
@@ -194,5 +199,6 @@ module.exports = {
   totalErrors: util.simpleQueryResponder(totalErrorsQuery, util.paramExtractor()),
   overviewErrors: function(scope) { return errorResponder(overallErrorQuery(scope)); },
   localityErrorsReport: util.simpleQueryResponder(localityErrors, util.paramExtractor()),
-  scopedLocalityErrors: function(scope) { return errorResponder(getScopedLocalityErrors(scope), ['localityId']); }
+  scopedLocalityErrors: function(scope) { return errorResponder(getScopedLocalityErrors(scope), ['localityId']); },
+  ballotMeasureOverallErrorQuery: function(element_type, scope) { return errorResponder(ballotMeasureOverallErrorQuery(element_type, scope)); }
 }


### PR DESCRIPTION
For [this bug card](https://www.pivotaltracker.com/story/show/149515783) this PR adds functions to `v5_1_queries.js` and `csv.js` to allow errors to be requested using both an element type (as pulled from an ltree path) as well as with a scope; this will solve the specific problem of ballot measure contest errors not getting pulled into their scoped error page and report.  I made it generic in case there are other error types that follow this same pattern.

The issue at hand is that the ballot measure contest errors in question (UTF-8 errors in the text) are saved as global errors rather than as errors established after the values have been added to `xml_tree_values`; so when they're added to `xml_tree_validations` they don't have `path` which is required for the original way the summary page and report were generated.  These changes allow the summary error page and report to be generated with both an `elementType` which works for errors that have an ltree path as well as a `scope`, which is all we have in the case of these global errors to determine where the error should be shown.

It should be noted that this does not impact the main errors page (and I've got approval from Maria to leave that part alone for now) which will show the incorrect number of errors.  There is a single function in `data-processor` that generates the data to populate the main error and updating that to pull these global errors for their related elements is a more significant undertaking that we'll put aside for now.  There is a Michigan feed noted in the bug card that can used to test this locally.