### PR TITLE
Alaska and Arizona were missing from the state list we use to translate fips codes to state names for email notifications

### DIFF
--- a/notifications/content.js
+++ b/notifications/content.js
@@ -3,6 +3,8 @@ var baseUrl = process.env.BASE_URI || "localdocker:4000";
 var codes = {
   "admin": "Admin Group",
   "01": "Alabama",
+  "02": "Alaska",
+  "04": "Arizona",
   "05": "Arkansas",
   "06": "California",
   "08": "Colorado",


### PR DESCRIPTION
Not a huge change, just realized when I was copying the fips codes in the notifications code over to use for the select element on the create elections form that somehow we're missing Alaska and Arizona (which I specifically noticed by singing "Fifty Nifty United States" to myself).