### PR TITLE
Only need to set hasRole in rootScope once if we do it correctly

### DIFF
--- a/public/assets/js/app/app.js
+++ b/public/assets/js/app/app.js
@@ -361,6 +361,8 @@ vipApp.run(function ($rootScope, $appService, $location, $appProperties, $window
 
     }
 
+    $rootScope.hasRole = $authService.hasRole;
+
     $rootScope.getDueDateTextDays = function(date, now){
 
       var dueIn = "N/A"

--- a/public/assets/js/app/controllers/centralization/centralizationController.js
+++ b/public/assets/js/app/controllers/centralization/centralizationController.js
@@ -8,8 +8,6 @@ function CentralizationCtrl($scope, $rootScope, Upload, $configService, $route, 
   // initialize page header variables
   $scope.setPageHeader("VIP County Data Centralization Upload", breadcrumbs, "centralization", "", null);
 
-  $rootScope.hasRole = $authService.hasRole;
-
   $scope.cannotSubmit = function() {
     // the ui-date that is allowing the user to select their date via a calendar
     // is not fully compatible with angular 1.2.1, so this calls to a function

--- a/public/assets/js/app/controllers/feedsController.js
+++ b/public/assets/js/app/controllers/feedsController.js
@@ -42,7 +42,5 @@ function FeedsCtrl($scope, $rootScope, $feedDataPaths, $feedsService, $location,
     }
   };
 
-  $rootScope.hasRole = $authService.hasRole;
-
   getFeedResponse();
 }

--- a/public/assets/js/app/controllers/homeController.js
+++ b/public/assets/js/app/controllers/homeController.js
@@ -16,5 +16,5 @@ function HomeCtrl($scope, $rootScope, $homeService, $location, $routeParams, $au
   $scope.login = function() {
   	$authService.login();
   };
-  $rootScope.hasRole = $authService.hasRole;
+
 }


### PR DESCRIPTION
Refactor where we set hasRole to the rootScope. This way we only have to do it one place, and don't miss other pages we might add later.