### PR TITLE
update build/deploy scripts to work with newer agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,13 +119,19 @@ the Angular config file, you can return to using `node app.js` if you like.
 
 ## Deploying the Project
 
+### Automatic
+
+Merges to `master` branch will be deployed to production automatically.
+
+### Manual
+
 To deploy you will need the ssh key for the environment you are deploying to, access to [quay](https://quay.io/) where the docker container images are hosted, and the IP address for the cluster you wish to deploy to
 
-1. set the environment variable `FLEETCTL_TUNNEL` to the IP address of the cluster you're deploying to (`export FLEETCTL_TUNNEL=<ip_address>`)
+1. set the environment variable `FLEETCTL_TUNNEL` to the IP address of the cluster you're deploying to (`export FLEETCTL_TUNNEL=<ip_address>`), and if needed, add the ssh key to your agent, e.g. `ssh-add ~/.ssh/key.pem` where `key.pem` is the appropriate key for the environment you are deploying to.
 1. run `docker login quay.io` to login to quay
 2. run `./script/build staging|production` to build the docker image (use either `staging` or `production` depending on the environment you are deploying to.
 2. if you've successfully built the image, you should see output at the end that looks like this: `If you'd like to push this to the Docker repo, run: docker push quay.io/votinginfoproject/metis:master-somehash`; run that command to push the container to quay
-3. run `PEM_FILE=<path_to_pem_file> ./script/deploy` to deploy
+3. run `./script/deploy` to deploy
 
 [data-processor]: https://github.com/votinginfoproject/data-processor
 [node]: http://nodejs.org

--- a/script/build
+++ b/script/build
@@ -22,7 +22,7 @@ DOCKER_IMAGE=$DOCKER_REPO:$IMAGE_TAG
 echo '--- building docker image'
 docker build -t $DOCKER_IMAGE .
 
-if [[ $CI = "true" && $BUILDKITE_BRANCH = "master" ]]; then
+if [ $CI = "true" ]; then
     echo '--- pushing docker image to registry'
     docker login -e="." -u="${QUAY_USERNAME}" -p="${QUAY_PASSWORD}" quay.io
     docker push $DOCKER_IMAGE
@@ -36,7 +36,7 @@ cp ${SERVICE}@.service.template ${SERVICE}@.service
 perl -p -i -e "s|^Environment=DOCKER_IMAGE=.*$|Environment=DOCKER_IMAGE=${DOCKER_IMAGE}|" ${SERVICE}@.service
 perl -p -i -e "s|^Environment=RUN_ENV=.*$|Environment=RUN_ENV=${RUN_ENV}|" ${SERVICE}@.service
 
-if [[ $CI = "true" && $BUILDKITE_BRANCH = "master" ]]; then
+if hash buildkite-agent 2>/dev/null ; then
   echo '--- saving service file'
   buildkite-agent artifact upload ${SERVICE}@.service
 fi

--- a/script/deploy
+++ b/script/deploy
@@ -14,20 +14,13 @@ if [[ ! -e ${SERVICE}@.service ]]; then
   exit 1
 fi
 
-if [[ ! -e $PEM_FILE ]]; then
-  echo "Please provide a .pem file for the fleet"
-  exit 1
-fi
-
-eval "$(ssh-agent -s)"
-ssh-add $PEM_FILE
-
-fleetctl --strict-host-key-checking=false destroy ${SERVICE}@.service
+echo "--- sending fleet service file"
+fleetctl --strict-host-key-checking=false destroy ${SERVICE}@.service || true
 fleetctl --strict-host-key-checking=false submit ${SERVICE}@.service
 
 echo '--- (re-)starting fleet service instances'
 for i in {1..3}; do
-  fleetctl --strict-host-key-checking=false destroy ${SERVICE}@$i
+  fleetctl --strict-host-key-checking=false destroy ${SERVICE}@$i || true
   fleetctl --strict-host-key-checking=false start ${SERVICE}@$i
   # TODO: Use consul to see if ${SERVICE}@$i is healthy yet before moving on
 done


### PR DESCRIPTION
Update build/deploy scripts to work with new agents.

Primarily we drop the PEM_FILE requirement, and a few other tweaks so builds and artifacts savings will be run on all branches (so staging _can_ be deployed via BK as well).