### PR TITLE
remove link for more details at header of localities table on feed overview page

### DIFF
--- a/public/app/partials/5.1/feed-overview.html
+++ b/public/app/partials/5.1/feed-overview.html
@@ -15,11 +15,6 @@
         <h2>{{feedLocalities.length}} Localities</h2>
 
         <span ng-if="!feedLocalities" class="more-detail is-loading"></span>
-        <a class="more-detail"
-           ng-if="feedLocalities"
-           href="{{$location.absUrl()}}/election/state/localities/">
-          More Detail
-        </a>
       </header>
 
       <section class="data-group data-module">


### PR DESCRIPTION
Per [this bug card](https://www.pivotaltracker.com/story/show/152018192) the link for "more details" at the top of the localities table for 5.1 feeds returns to the main feeds page.  The 3.0 behavior is to a less-paginated list of the localities, instead of doing that (which doesn't add much functionality and would require additional work to implement) we're just going to remove the link for more details.