### PR TITLE
loosely handle parse error

### DIFF
--- a/aws/s3.js
+++ b/aws/s3.js
@@ -87,38 +87,45 @@ module.exports = {
   uploadCentralizationFile: function(req, res){
     var form = new multiparty.Form();
     form.parse(req, function(err, fields, files) {
-      console.log(fields.date);
-      console.log(files.file.path);
-      console.log(fields.fipsCode);
-      var date = fields["date"];
-      var fipsCode = fields["fipsCode"];
-      res.writeHead(200, {'content-type': 'text/plain'});
-      res.write('received upload:\n\n');
-      res.end(JSON.stringify(files));
-      var fileStream = fs.createReadStream(files.file.path);
-      fileStream.on('error', function (err) {
-        if (err) { throw err; }
-      });
-      fileStream.on('open', function () {
-        var s3 = new AWS.S3();
-        if (fipsCode === undefined) {
-          fipsCode = "undefined"
-        };
-        fips2 = fipsCode.slice(0, 2);
-        var fileName = fips2+ '/' + fipsCode + '/' + date + '/' + files.file.originalFilename;
-        logger.info("putting file with name '" + fileName + "' into bucket '" + centralizationBucket + "'");
-        s3.putObject({
-          Bucket: centralizationBucket,
-          Key: fileName,
-          Body: fileStream
-        }, function (err) {
-          if (err) {
-            console.log("Error uploading centralization data file:");
-            console.log(err);
-            throw err;
-          }
+      if (err) {
+        logger.error("Error uploading centralization file: ", err);
+        //change this status code when we know more about what we're dealing with
+        res.writeHead(200, {'content-type': 'text/plain'});
+        res.end();
+      } else {
+        logger.info(fields.date);
+        logger.info(files.file.path);
+        logger.info(fields.fipsCode);
+        var date = fields["date"];
+        var fipsCode = fields["fipsCode"];
+        res.writeHead(200, {'content-type': 'text/plain'});
+        res.write('received upload:\n\n');
+        res.end(JSON.stringify(files));
+        var fileStream = fs.createReadStream(files.file.path);
+        fileStream.on('error', function (err) {
+          if (err) { throw err; }
         });
-      });
+        fileStream.on('open', function () {
+          var s3 = new AWS.S3();
+          if (fipsCode === undefined) {
+            fipsCode = "undefined"
+          };
+          fips2 = fipsCode.slice(0, 2);
+          var fileName = fips2+ '/' + fipsCode + '/' + date + '/' + files.file.originalFilename;
+          logger.info("putting file with name '" + fileName + "' into bucket '" + centralizationBucket + "'");
+          s3.putObject({
+            Bucket: centralizationBucket,
+            Key: fileName,
+            Body: fileStream
+          }, function (err) {
+            if (err) {
+              console.log("Error uploading centralization data file:");
+              console.log(err);
+              throw err;
+            }
+          });
+        });
+      }
     });
     return;
   },


### PR DESCRIPTION
Put in a conditional to check for the err condition and respond in a non-error throwy way when it happens on a file upload.

This is mostly about 2 things at the moment:
1) We don't know how this is affecting users or how they are triggering it. So dealing with the error and printing things out to the logs should help us figure that out some more.
2) Since user's aren't reporting issues and we do seem to be getting all the data we need, we're returning an ok status code to not needlessly alarm users right now. We could change all that if/when we figure things out based on the logging.

So this isn't really intended to be the last word in fixing this issue, just a step to help us figure out what is really broken so we can make a better fix later.

[Pivotal Card](https://www.pivotaltracker.com/story/show/154531383)