### PR TITLE
actually return the value so it's not undefined

### DIFF
--- a/early-vote/file-generation.js
+++ b/early-vote/file-generation.js
@@ -160,7 +160,7 @@ var earlyVoteSiteToCsv = (earlyVoteSite, hoursOpenId, idGenerator) =>
     "id": idGenerator("evs_pl_")
   });
 
-var formatDate = (date) => {moment(date).format('YYYY-MM-DD')};
+var formatDate = (date) => {return moment(date).format('YYYY-MM-DD')};
 
 var timezoneToOffset = {
   "EST": "-05:00",


### PR DESCRIPTION
I looked at generated files, figured out we had dates in the files on Nov 15th and we didn't as of Nov 20th. That pointed me to a commit where I changed the `formatDate` function, and apparently this form of arrow function needed a return statement to function properly.

[Pivotal Card](https://www.pivotaltracker.com/story/show/154976073)