### PR TITLE
check for existence of roles

### DIFF
--- a/notifications/sender.js
+++ b/notifications/sender.js
@@ -15,7 +15,8 @@ var transporter = nodemailer.createTransport(sesTransport({
 }));
 
 var dataCentralizationOnly = function(user) {
-  return user.app_metadata.roles.length == 1 &&
+  return user.app_metadata.roles &&
+         user.app_metadata.roles.length == 1 &&
          user.app_metadata.roles[0] == 'data-centralization';
 };
 


### PR DESCRIPTION
Some small set of our users don't appear to have any roles set at all, in which case notifications blow up because the code was blindly checking for existence of a certain role only. This should fix this situation.

In this instance, we'll go ahead and still send the notification as they won't be a `data-centralization` only user by definition.

[Pivotal Bug Card](https://www.pivotaltracker.com/story/show/156095287)