### PR TITLE
stop sending the error info back on error responses

### DIFF
--- a/dashboard/util.js
+++ b/dashboard/util.js
@@ -16,7 +16,6 @@ module.exports = {
         if(err) {
           logger.error(err.name + ": " + err.message);
           res.writeHead(500, {'Content-Type': 'text/plain'});
-          res.write(err.name + ": " + err.message);
           res.end();
         } else {
           resp.writeResponse(result.rows, res);
@@ -40,7 +39,6 @@ module.exports = {
         if(err) {
           logger.error(err.name + ": " + err.message);
           res.writeHead(500, {'Content-Type': 'text/plain'});
-          res.write(err.name + ": " + err.message);
           res.end();
         } else {
           res.writeHead(201, {'Content-Type': 'application/json'});


### PR DESCRIPTION
[Pivotal Card](https://www.pivotaltracker.com/story/show/157015613)
[Demo](https://democracyworks.slack.com/files/U03CREBTW/FBCQRTL15/http-response-not-showing-errors.mp4)

(I realize I didn't demo with the `-v` curl flag, but I tried it later to verify that no, we don't send the error message back in some not shown format, and then a successful response is still successful)