### PR TITLE
This was easy

### DIFF
--- a/src/cljs/early_vote_site/elections/views.cljs
+++ b/src/cljs/early_vote_site/elections/views.cljs
@@ -59,7 +59,7 @@
 (defn election-list-row
   [election]
   (let [roles @(re-frame/subscribe [:roles])
-        admin? (seq (set/intersection roles #{"super-admin" "state-admin"}))
+        admin? (seq (set/intersection roles #{"super-admin"}))
         editing @(re-frame/subscribe [:elections/editing])]
     (if (contains? editing (:id election))
       [form (:id election)]


### PR DESCRIPTION
Was already set up to allow these actions for either `super-admin` or `state-admin`, so just needed to remove `state-admin` from consideration and now these are protected.

[Pivotal Card](https://www.pivotaltracker.com/story/show/159485068)