### PR TITLE
give super-admins the ability to filter files

### DIFF
--- a/aws/s3.js
+++ b/aws/s3.js
@@ -143,7 +143,11 @@ module.exports = {
     var bucketName = centralizationBucket;
 
     if (auth.isSuperAdmin(req)){
-      prefix = "";
+      if (req.query['prefix']) {
+        prefix = req.query['prefix'];
+      } else {
+        prefix = "";
+      }
     } else {
       fips2 = fipsCode.slice(0, 2);
       var prefix = fips2 + '/' + fipsCode;

--- a/public/app/partials/centralization/centralization.html
+++ b/public/app/partials/centralization/centralization.html
@@ -20,6 +20,12 @@
     </form>
   </div>
 
+  <div ng-if="hasRole('super-admin')">
+    <label>Filter By State</label>
+    <select ng-model="selectedState" ng-options="x.state for x in states" ng-change="getFiles(selectedState)">
+    </select>
+  </div>
+
   <br>
   <div ng-if="submittedFiles.length > 0">
   <label>Previously submitted files:</label>

--- a/public/assets/js/app/controllers/centralization/centralizationController.js
+++ b/public/assets/js/app/controllers/centralization/centralizationController.js
@@ -26,6 +26,60 @@ function CentralizationCtrl($scope, $rootScope, Upload, $configService, $route, 
     }
   };
 
+	$scope.states =
+	[{fipsCode: "", state: "All"},
+	 {fipsCode: "01",  state: "Alabama" },
+	 {fipsCode: "02",  state: "Alaska" },
+	 {fipsCode: "04",  state: "Arizona" },
+	 {fipsCode: "05",  state: "Arkansas" },
+	 {fipsCode: "06",  state: "California" },
+	 {fipsCode: "08",  state: "Colorado" },
+	 {fipsCode: "09",  state: "Connecticut" },
+	 {fipsCode: "10",  state: "Delaware" },
+	 {fipsCode: "11",  state: "District of Columbia" },
+	 {fipsCode: "12",  state: "Florida" },
+	 {fipsCode: "13",  state: "Georgia" },
+	 {fipsCode: "15",  state: "Hawaii" },
+	 {fipsCode: "16",  state: "Idaho" },
+	 {fipsCode: "17",  state: "Illinois" },
+	 {fipsCode: "18",  state: "Indiana" },
+	 {fipsCode: "19",  state: "Iowa" },
+	 {fipsCode: "20",  state: "Kansas" },
+	 {fipsCode: "21",  state: "Kentucky" },
+	 {fipsCode: "22",  state: "Louisiana" },
+	 {fipsCode: "23",  state: "Maine" },
+	 {fipsCode: "24",  state: "Maryland" },
+	 {fipsCode: "25",  state: "Massachusetts" },
+	 {fipsCode: "26",  state: "Michigan" },
+	 {fipsCode: "27",  state: "Minnesota" },
+	 {fipsCode: "28",  state: "Mississippi" },
+	 {fipsCode: "29",  state: "Missouri" },
+	 {fipsCode: "30",  state: "Montana" },
+	 {fipsCode: "31",  state: "Nebraska" },
+	 {fipsCode: "32",  state: "Nevada" },
+	 {fipsCode: "33",  state: "New Hampshire" },
+	 {fipsCode: "34",  state: "New Jersey" },
+	 {fipsCode: "35",  state: "New Mexico" },
+	 {fipsCode: "36",  state: "New York" },
+	 {fipsCode: "37",  state: "North Carolina" },
+	 {fipsCode: "38",  state: "North Dakota" },
+	 {fipsCode: "39",  state: "Ohio" },
+	 {fipsCode: "40",  state: "Oklahoma" },
+	 {fipsCode: "41",  state: "Oregon" },
+	 {fipsCode: "42",  state: "Pennsylvania" },
+	 {fipsCode: "44",  state: "Rhode Island" },
+	 {fipsCode: "45",  state: "South Carolina" },
+	 {fipsCode: "46",  state: "South Dakota" },
+	 {fipsCode: "47",  state: "Tennessee" },
+	 {fipsCode: "48",  state: "Texas" },
+	 {fipsCode: "49",  state: "Utah" },
+	 {fipsCode: "50",  state: "Vermont" },
+	 {fipsCode: "51",  state: "Virginia" },
+	 {fipsCode: "53",  state: "Washington" },
+	 {fipsCode: "54",  state: "West Virginia" },
+	 {fipsCode: "55",  state: "Wisconsin" },
+	 {fipsCode: "56",  state: "Wyoming" }];
+
   $scope.submit = function() {
     // check that we have a date and a file
     if(!$scope.cannotSubmit()) {
@@ -53,8 +107,16 @@ function CentralizationCtrl($scope, $rootScope, Upload, $configService, $route, 
     });
   };
 
-  if ($rootScope.user) {
-    $configService.getResponse({path: '/centralization/submitted-files', config: {}},
+	$scope.getFiles = function(selectedState) {
+		var cfg = {};
+		if (selectedState) {
+			cfg = {params: {prefix: selectedState.fipsCode}};
+		}
+    $configService.getResponse({path: '/centralization/submitted-files', config: cfg},
                                function(result) { $scope.submittedFiles = result; });
+	}
+
+  if ($rootScope.user) {
+		$scope.getFiles();
   }
 };


### PR DESCRIPTION
There's no Pivotal Card for this, it's an outcome of looking into some issues we're seeing with the Data Centralization file list for super-admins.

Allows super-admin users to pick a state to
filter the files by that state, taking advantage
of the prefixing we've done.

Since we've hit a 1000 file limit, this was the
quickest way for now to both introduce a useful
feature and to give us some breathing room while
we consider a more stable long term solution.