### PR TITLE
Fix ev queries

### DIFF
--- a/early-vote/access.js
+++ b/early-vote/access.js
@@ -174,8 +174,8 @@ function verifySchedule(req, res, next) {
 }
 
 var protectScheduleSql =
-	`select evs.id from early_vote_sites evs left join assignments ass on evs.id = ass.early_vote_site_id
-	  join schedules s on ass.schedule_id = s.id where s.id = $1 and evs.county_fips not in ($2);`
+	`select evs.id from early_vote_sites evs left join assignments asgts on evs.id = asgts.early_vote_site_id
+	  join schedules s on asgts.schedule_id = s.id where s.id = $1 and evs.county_fips not in ($2);`
 var protectScheduleParamFn = util.compoundParamExtractor([util.pathParamExtractor(['scheduleid']),
 																													fipsExtractor()]);
 /**
@@ -199,12 +199,12 @@ function protectSchedule(req, res, next) {
 
 var verifyAssignmentStateSql =
 	`select e.id from elections e left join schedules s on e.id = s.election_id
-	 left join assignments as on s.id = as.schedule_id where as.id = $1 and e.state_fips in ($2);`
+	 left join assignments asgts on s.id = asgts.schedule_id where asgts.id = $1 and e.state_fips in ($2);`
 var verifyAssignmentStateParamFn = util.compoundParamExtractor([util.pathParamExtractor(['assignmentid']),
 																												 				stateFipsExtractor()]);
 var verifyAssignmentCountySql =
-	`select evs.id from early_vote_sites evs left join assignments ass on evs.id = ass.early_vote_site_id
-	 where ass.id = $1 and evs.county_fips in ($2);`
+	`select evs.id from early_vote_sites evs left join assignments asgts on evs.id = asgts.early_vote_site_id
+	 where asgts.id = $1 and evs.county_fips in ($2);`
 var verifyAssignmentCountyParamFn = util.compoundParamExtractor([util.pathParamExtractor(['assignmentid']),
 																												 				fipsExtractor()]);
  /**

--- a/src/cljs/early_vote_site/early_vote_site_detail/events.cljs
+++ b/src/cljs/early_vote_site/early_vote_site_detail/events.cljs
@@ -198,7 +198,7 @@
 (defn delete-schedule-success
   [{:keys [db]} [_ early-vote-site-id]]
   {:db db
-   :dispatch-n [[:flash/message "Early vote site deleted"]
+   :dispatch-n [[:flash/message "Schedule deleted"]
                 [:schedules-list/get]]})
 
 (def events


### PR DESCRIPTION
State Admins can't unassign/delete schedules because the query to verify that they should have access was incorrect. So this fixes that query and uses a consistent alias for the assignments table in the `access.js` file. Also, when a schedule was deleted, it said the Early Vote Site was deleted in the flash message, so that is also fixed here.