### PR TITLE
Remove the sidebar navigation to the Batch Address Test Tool

### DIFF
--- a/public/app/partials/testing/aside.html
+++ b/public/app/partials/testing/aside.html
@@ -4,7 +4,6 @@
       <nav class="left-nav">
         <ul>
           <li><a id="sidebar-vit" href="#/testing/vit">VIT Staging</a></li>
-          <li><a id="sidebar-vit" href="#/testing/addresses">Batch Address Test Tool</a></li>
         </ul>
       </nav>
     </div>


### PR DESCRIPTION
[VIP-119](https://democracyworks.atlassian.net/browse/VIP-119?atlOrigin=eyJpIjoiY2Y5Yjk3MzM5NjI2NGZmYzhjMmU2YThiMWIxOGY0MmUiLCJwIjoiaiJ9)

Only removing the link to get to the Batch Address Testing page for now. We may want to bring this back sooner (if we get time to fix up the security issues) or later (as part of a redesign of the dashboard).