### PR TITLE
Vit 312 vit dashboard upgrade

### DIFF
--- a/public/vit.html
+++ b/public/vit.html
@@ -1,11 +1,12 @@
 <!doctype html>
 <html>
   <head>
-      <!-- VIT Staging Tool -->
-      <script type="text/javascript" src="https://tool-staging.votinginfoproject.org/app.js"></script>
+      <!-- VIT Source -->
+      <script type="text/javascript" src="https://votinginfotool.org/js/compiled/app.js"></script>
+      <link rel="stylesheet" href="https://votinginfotool.org/css/compiled/vit.css"/>
   </head>
 <body>
-  <div id="_vit" style="max-width: 1024px; margin: 0 auto 0 0;"></div>
+  <div id="_vit" style="max-width: 1024px; height: 480px; margin: 0 auto 0 0;"></div>
   <script type="text/javascript">
     function getQueryParams(qs) {
       qs = qs.split("+").join(" ");
@@ -22,10 +23,11 @@
       var params = getQueryParams(window.location.search.substring(1));
       var apiKey = params['apiKey'];
       if(apiKey) {
-        vit.load({key: apiKey,
-                  test: false,
-                  officialOnly: true,
-                  productionDataOnly: false});
+        vit.core.init("_vit", {"logo": {"type": "default"},
+                               "civic-info-api-key": apiKey,
+                               "official-only": true,
+                               "production-data-only": false,
+                               "display-mode": "desktop"});
       } else {
         alert("Civic Info API Key missing");
       }


### PR DESCRIPTION
[Jira Card](https://democracyworks.atlassian.net/browse/VIP-312)

One of two PRs for this card, this updates the Dashboard code to use the new VIT. Needs to be paired with a PR in `gttp-relaunch` that allows the VIT to be configured with a Civic Info API Key that takes precedence over the one that was built into the deployment. This allows us to use the main production codebase, but override the Civic Info API Key to one that can access staged data. We can't use any of the staging deployments of the VIT as they are behind https basic auth challenges that prevent it from embedding properly.